### PR TITLE
feat(rust): update FFI structs and API to match navio-core SHA 623ad2da

### DIFF
--- a/ffi/rust/.rustfmt.toml
+++ b/ffi/rust/.rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 2

--- a/ffi/rust/build.rs
+++ b/ffi/rust/build.rs
@@ -3,13 +3,12 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use num_cpus;
 
 const IS_PROD: bool = true;
 
 const NAVIO_REPO_URL_PROD: &str = "https://github.com/nav-io/navio-core";
 const NAIVO_REPO_URL_DEV: &str = "https://github.com/gogoex/navio-core";
-const NAVIO_REPO_PROD_SHA: &str = "4704c8ae116a107c902ef33e11a8c564cd68efc3";
+const NAVIO_REPO_PROD_SHA: &str = "623ad2da8e9031d8b900c54af6d393ec88e9a32a";
 const NAVIO_REPO_DEV_BRANCH: &str = "";
 
 fn copy_dir(src_dir: &Path, dest_dir: &Path) -> io::Result<()> {
@@ -18,7 +17,7 @@ fn copy_dir(src_dir: &Path, dest_dir: &Path) -> io::Result<()> {
   for f in fs::read_dir(src_dir)? {
     let f = f?;
     let f = f.path();
-    let dest_path = dest_dir.join(&f.file_name().unwrap());
+    let dest_path = dest_dir.join(f.file_name().unwrap());
 
     if f.is_file() {
       fs::copy(&f, &dest_path)?;
@@ -30,10 +29,8 @@ fn copy_dir(src_dir: &Path, dest_dir: &Path) -> io::Result<()> {
 }
 
 fn get_navio_core_path() -> PathBuf {
-  let manifest_dir = PathBuf::from(
-    env::var("CARGO_MANIFEST_DIR")
-      .expect("CARGO_MANIFEST_DIR not set")
-  );
+  let manifest_dir =
+    PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
   manifest_dir.join("target").join("navio-core")
 }
 
@@ -48,9 +45,9 @@ fn clone_navio_core(navio_core_path: &Path) {
 
   // construct git clone command
   let (repo_url, branch) = match IS_PROD {
-    true => (NAVIO_REPO_URL_PROD, None), 
+    true => (NAVIO_REPO_URL_PROD, None),
     false => (NAIVO_REPO_URL_DEV, Some(NAVIO_REPO_DEV_BRANCH)),
-  }; 
+  };
   let mut args = vec!["clone", "--depth", "1"];
   if let Some(branch) = branch {
     args.push("--branch");
@@ -75,14 +72,14 @@ fn clone_navio_core(navio_core_path: &Path) {
       .args(args)
       .current_dir(navio_core_path)
       .status()
-      .expect(format!("Failed to fetch commit {NAVIO_REPO_PROD_SHA}").as_str());
+      .unwrap_or_else(|_| panic!("Failed to fetch commit {NAVIO_REPO_PROD_SHA}"));
 
     let args = vec!["checkout", NAVIO_REPO_PROD_SHA];
     Command::new("git")
       .args(args)
       .current_dir(navio_core_path)
       .status()
-      .expect(format!("Failed to checkout commit {NAVIO_REPO_PROD_SHA}").as_str());
+      .unwrap_or_else(|_| panic!("Failed to checkout commit {NAVIO_REPO_PROD_SHA}"));
   }
 }
 
@@ -94,8 +91,7 @@ fn get_depends_arch_path(depends_path: &Path) -> io::Result<PathBuf> {
     ));
   }
   let arches = [
-    "x86_64", "i686", "mips", "arm", "aarch64",
-    "powerpc", "riscv32", "riscv64", "s390x"
+    "x86_64", "i686", "mips", "arm", "aarch64", "powerpc", "riscv32", "riscv64", "s390x",
   ];
   for entry in fs::read_dir(depends_path)? {
     let entry = entry?;
@@ -118,22 +114,22 @@ fn get_depends_arch_path(depends_path: &Path) -> io::Result<PathBuf> {
 }
 
 fn build_depends(
-  navio_core_path: &Path, 
+  navio_core_path: &Path,
   depends_path: &Path,
   num_cpus: &str,
 ) -> io::Result<PathBuf> {
-  let depends_bak_path =
-    navio_core_path
-      .parent().unwrap()
-      .parent().unwrap()
-      .join("depends");
+  let depends_bak_path = navio_core_path
+    .parent()
+    .unwrap()
+    .parent()
+    .unwrap()
+    .join("depends");
 
   if depends_bak_path.exists() {
     println!("Copying backup of depends under navio-core...");
 
-    fs::remove_dir_all(&depends_path).unwrap();
-    copy_dir(&depends_bak_path, &depends_path).unwrap();
-
+    fs::remove_dir_all(depends_path).unwrap();
+    copy_dir(&depends_bak_path, depends_path).unwrap();
   } else {
     // if there is no backup directory of depends dir,
     // build navio-core dependencies and create the backup
@@ -143,10 +139,10 @@ fn build_depends(
       .current_dir(depends_path)
       .status()
       .expect("Failed to clone navio-core repository");
-  
+
     // create the backup
     println!("Creating backup of navio-core dependencies...");
-    copy_dir(&depends_path, &depends_bak_path).unwrap();
+    copy_dir(depends_path, &depends_bak_path).unwrap();
   }
 
   get_depends_arch_path(depends_path)
@@ -162,7 +158,7 @@ fn build_libblsct(
   println!("Building libblsct.a and its dependencies...");
 
   Command::new("./autogen.sh")
-    .current_dir(&navio_core_path)
+    .current_dir(navio_core_path)
     .status()
     .expect("Failed to run autogen.sh");
 
@@ -171,25 +167,29 @@ fn build_libblsct(
       &format!("--prefix={}", depends_arch_path.display()),
       "--enable-build-libblsct-only",
     ])
-    .current_dir(&navio_core_path)
+    .current_dir(navio_core_path)
     .status()
     .expect("Failed to run configure");
 
   Command::new("make")
-    .args(["-j", &num_cpus])
-    .current_dir(&navio_core_path)
+    .args(["-j", num_cpus])
+    .current_dir(navio_core_path)
     .status()
     .expect("Failed to build libblsct");
 
   // copy libblsct.a and its dependencies to libs directory
   for (src, dest) in dot_a_src_dest_paths {
     println!("Copying {} to {}...", &src.display(), &dest.display());
-    fs::copy(&src, &dest).unwrap();
+    fs::copy(src, dest).unwrap();
   }
 }
 
 fn print_link_instructions(libs_path: &Path) {
-  println!("cargo:rustc-link-lib=c++");
+  if cfg!(target_os = "macos") {
+    println!("cargo:rustc-link-lib=c++");
+  } else {
+    println!("cargo:rustc-link-lib=stdc++");
+  }
 
   // library search path
   println!("cargo:rustc-link-search=native={}", libs_path.display());
@@ -210,28 +210,35 @@ fn get_lib_paths(navio_core_path: &Path, libs_path: &Path) -> Vec<(PathBuf, Path
 
   vec![
     (src_path.join("libblsct.a"), libs_path.join("libblsct.a")),
-    (src_path.join("libunivalue_blsct.a"), libs_path.join("libunivalue_blsct.a")),
+    (
+      src_path.join("libunivalue_blsct.a"),
+      libs_path.join("libunivalue_blsct.a"),
+    ),
     (mcl_lib_path.join("libmcl.a"), libs_path.join("libmcl.a")),
-    (bls_lib_path.join("libbls384_256.a"), libs_path.join("libbls384_256.a")),
+    (
+      bls_lib_path.join("libbls384_256.a"),
+      libs_path.join("libbls384_256.a"),
+    ),
   ]
 }
 
 fn prepare_fresh_libs_dir(libs_path: &Path) {
   if libs_path.exists() {
-    fs::remove_dir_all(&libs_path).unwrap();
+    fs::remove_dir_all(libs_path).unwrap();
   }
-  fs::create_dir(&libs_path).unwrap();
+  fs::create_dir(libs_path).unwrap();
 }
 
 fn main() {
   let navio_core_path = get_navio_core_path();
   let libs_path = navio_core_path
-    .parent().unwrap()
-    .parent().unwrap()
+    .parent()
+    .unwrap()
+    .parent()
+    .unwrap()
     .join("libs");
 
-  let dot_a_src_dest_paths =
-    get_lib_paths(&navio_core_path, &libs_path);
+  let dot_a_src_dest_paths = get_lib_paths(&navio_core_path, &libs_path);
 
   // build libblsct.a and its dependency if not built yet
   if dot_a_src_dest_paths.iter().any(|(_, dest)| !dest.exists()) {
@@ -242,11 +249,7 @@ fn main() {
 
     clone_navio_core(&navio_core_path);
 
-    let depends_arch_path = build_depends(
-      &navio_core_path,
-      &depends_path,
-      &num_cpus,
-    ).unwrap();
+    let depends_arch_path = build_depends(&navio_core_path, &depends_path, &num_cpus).unwrap();
 
     build_libblsct(
       &navio_core_path,
@@ -258,4 +261,3 @@ fn main() {
 
   print_link_instructions(&libs_path);
 }
-

--- a/ffi/rust/src/address.rs
+++ b/ffi/rust/src/address.rs
@@ -1,27 +1,16 @@
 use crate::keys::double_public_key::DoublePublicKey;
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  ffi::{
-    AddressEncoding,
-    decode_address,
-    encode_address,
-    free_obj,
-  },
+  blsct_obj::{self, BlsctObj},
+  ffi::{decode_address, encode_address, free_obj, AddressEncoding},
 };
-use std::ffi::{
-  c_char,
-  c_void,
-  CStr,
-  CString,
-  NulError,
-};
+use std::ffi::{c_char, c_void, CStr, CString, NulError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error<'a> {
   #[error("Failed to allocate memory for {0:?}")]
   FailedToAllocateMemory(&'static str),
-  
+
   #[error("Failed to construct BlsctRetVal: {0:?}")]
   FailedToConstructBlsctRetVal(blsct_obj::Error<'a>),
 
@@ -41,16 +30,14 @@ impl Address {
   pub fn encode(
     addr_dpk: &DoublePublicKey,
     encoding: AddressEncoding,
-  ) -> Result<String, Error> {
+  ) -> Result<String, Error<'_>> {
     let rv = unsafe { encode_address(addr_dpk.value(), encoding) };
     if rv.is_null() {
       unsafe { free_obj(rv as *mut c_void) };
       Err(Error::FailedToAllocateMemory("BlsctRetVal"))
-
     } else if unsafe { (*rv).result != 0 } {
       unsafe { free_obj(rv as *mut c_void) };
       Err(Error::FailedToEncodeAddress(addr_dpk))
-
     } else {
       let addr_c_str = unsafe { CStr::from_ptr((*rv).value as *const c_char) };
       let addr = addr_c_str.to_str().unwrap().to_string();
@@ -59,22 +46,18 @@ impl Address {
     }
   }
 
-  pub fn decode(addr_str: &str) -> Result<DoublePublicKey, Error> {
-    let c_addr_str = CString::new(addr_str)
-      .map_err(|e| Error::FailedToConstructCString(e))?;
+  pub fn decode(addr_str: &str) -> Result<DoublePublicKey, Error<'_>> {
+    let c_addr_str = CString::new(addr_str).map_err(Error::FailedToConstructCString)?;
 
     let rv = unsafe { decode_address(c_addr_str.as_ptr()) };
     if rv.is_null() {
       unsafe { free_obj(rv as *mut c_void) };
       Err(Error::FailedToAllocateMemory("BlsctRetVal"))
-
     } else if unsafe { (*rv).result != 0 } {
       unsafe { free_obj(rv as *mut c_void) };
       Err(Error::FailedToDecodeAddress(addr_str))
-
     } else {
-      let addr_dpk = BlsctObj::from_retval(rv)
-        .map_err(|e| Error::FailedToConstructBlsctRetVal(e))?;
+      let addr_dpk = BlsctObj::from_retval(rv).map_err(Error::FailedToConstructBlsctRetVal)?;
       Ok(addr_dpk.into())
     }
   }
@@ -83,10 +66,7 @@ impl Address {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    keys::double_public_key::DoublePublicKey,
-  };
+  use crate::{initializer::init, keys::double_public_key::DoublePublicKey};
 
   #[test]
   fn test_encode_decode() {
@@ -101,4 +81,3 @@ mod tests {
     }
   }
 }
-

--- a/ffi/rust/src/amount_recovery_req.rs
+++ b/ffi/rust/src/amount_recovery_req.rs
@@ -1,8 +1,4 @@
-use crate::{
-  point::Point,
-  range_proof::RangeProof,
-  token_id::TokenId,
-};
+use crate::{point::Point, range_proof::RangeProof, token_id::TokenId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Eq)]
@@ -32,19 +28,16 @@ impl AmountRecoveryReq {
 
 impl PartialEq for AmountRecoveryReq {
   fn eq(&self, other: &Self) -> bool {
-    self.range_proof == other.range_proof &&
-    self.nonce == other.nonce &&
-    self.token_id == other.token_id
+    self.range_proof == other.range_proof
+      && self.nonce == other.nonce
+      && self.token_id == other.token_id
   }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    token_id::TokenId,
-  };
+  use crate::{initializer::init, token_id::TokenId};
 
   #[test]
   fn test_deser() {

--- a/ffi/rust/src/amount_recovery_res.rs
+++ b/ffi/rust/src/amount_recovery_res.rs
@@ -19,9 +19,7 @@ impl AmountRecoveryRes {
 
 impl PartialEq for AmountRecoveryRes {
   fn eq(&self, other: &Self) -> bool {
-    self.is_succ == other.is_succ 
-    && self.amount == other.amount
-    && self.msg == other.msg
+    self.is_succ == other.is_succ && self.amount == other.amount && self.msg == other.msg
   }
 }
 
@@ -42,4 +40,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/blsct_obj.rs
+++ b/ffi/rust/src/blsct_obj.rs
@@ -1,27 +1,15 @@
-use std::slice;
 use crate::{
   blsct_serde::BlsctSerde,
-  ffi::{
-    BlsctRetVal,
-    free_obj,
-  },
+  ffi::{free_obj, malloc, BlsctRetVal},
 };
+use std::slice;
 
 use serde::{
-  de::Error as DeError,
-  ser::Error as SerError,
-  Deserialize,
-  Deserializer,
-  Serialize,
-  Serializer,
+  de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{
   any::type_name,
-  ffi::{
-    c_void,
-    CStr,
-    CString,
-  },
+  ffi::{c_void, CStr, CString},
   fmt,
   ptr::NonNull,
 };
@@ -37,10 +25,12 @@ impl<'a> std::error::Error for Error<'a> {}
 impl<'a> fmt::Display for Error<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::FailedToAllocateMemory(target) =>
-        write!(f, "Failed to allocate memory for {target}"),
-      Error::FailedToGenerateObject(target) =>
-        write!(f, "Failed to generate object for {target}"),
+      Error::FailedToAllocateMemory(target) => {
+        write!(f, "Failed to allocate memory for {target}")
+      }
+      Error::FailedToGenerateObject(target) => {
+        write!(f, "Failed to generate object for {target}")
+      }
     }
   }
 }
@@ -91,10 +81,7 @@ impl<T: BlsctSerde, U> BlsctObj<T, U> {
     }
   }
 
-  pub fn new(
-    ptr: NonNull<u8>,
-    size: usize,
-  ) -> Self {
+  pub fn new(ptr: NonNull<u8>, size: usize) -> Self {
     Self {
       ptr,
       size,
@@ -109,19 +96,21 @@ impl<T: BlsctSerde, U> BlsctObj<T, U> {
     if rv.is_null() {
       return Err(Error::FailedToAllocateMemory("BlsctRetVal"));
     }
-    let (result, value, value_size) = unsafe {
-      ((*rv).result, (*rv).value, (*rv).value_size)
-    };
+    let (result, value, value_size) = unsafe { ((*rv).result, (*rv).value, (*rv).value_size) };
 
     // BlscRetVal is no longer needed
-    unsafe { free_obj(rv as *mut c_void); }
+    unsafe {
+      free_obj(rv as *mut c_void);
+    }
 
     // check if generating object is failed
     if result != 0 {
       return Err(Error::FailedToGenerateObject(type_name::<Self>()));
     }
-    assert!(!value.is_null(),
-      "the value is null altough result is 0. check code.");
+    assert!(
+      !value.is_null(),
+      "the value is null altough result is 0. check code."
+    );
 
     let ptr = NonNull::new(value as *mut u8).unwrap();
 
@@ -146,10 +135,23 @@ impl<T: BlsctSerde, U> BlsctObj<T, U> {
     }
   }
 
-  pub fn from_c_obj_and_size(
-    c_obj: *mut c_void,
-    size: usize,
-  ) -> Self {
+  pub fn copy_from_c_obj(c_obj: *const U) -> Self {
+    let size = std::mem::size_of::<U>();
+    let new_ptr = unsafe {
+      let buf = malloc(size) as *mut u8;
+      std::ptr::copy_nonoverlapping(c_obj as *const u8, buf, size);
+      NonNull::new(buf).unwrap()
+    };
+    Self {
+      ptr: new_ptr,
+      size,
+      _t: std::marker::PhantomData,
+      _u: std::marker::PhantomData,
+      deallocator: None,
+    }
+  }
+
+  pub fn from_c_obj_and_size(c_obj: *mut c_void, size: usize) -> Self {
     let ptr = NonNull::new(c_obj as *mut u8).unwrap();
     Self {
       ptr,
@@ -160,9 +162,13 @@ impl<T: BlsctSerde, U> BlsctObj<T, U> {
     }
   }
 
-  #[inline] pub fn size(&self) -> usize { self.size }
+  #[inline]
+  pub fn size(&self) -> usize {
+    self.size
+  }
 
-  #[inline] pub fn as_ptr(&self) -> *const U {
+  #[inline]
+  pub fn as_ptr(&self) -> *const U {
     self.ptr.as_ptr() as *const U
   }
 }
@@ -171,7 +177,9 @@ impl<T: BlsctSerde, U> BlsctObj<T, U> {
 // and return a pointer to a c-string (null-terminated byte sequence)
 impl<T: BlsctSerde, U> Serialize for BlsctObj<T, U> {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where S: Serializer {
+  where
+    S: Serializer,
+  {
     let c_hex = unsafe { T::serialize(self.as_ptr() as *const u8, self.size()) };
     if c_hex.is_null() {
       return Err(SerError::custom("Serialization failed. c_hex is null"));
@@ -181,7 +189,9 @@ impl<T: BlsctSerde, U> Serialize for BlsctObj<T, U> {
       .map_err(|e| SerError::custom(format!("Converting C-Str to String failed: {:?}", e)))?
       .to_owned();
 
-    unsafe { free_obj(c_hex as *mut c_void); }
+    unsafe {
+      free_obj(c_hex as *mut c_void);
+    }
 
     serializer.serialize_str(&hex)
   }
@@ -191,26 +201,27 @@ impl<T: BlsctSerde, U> Serialize for BlsctObj<T, U> {
 // and return a pointer to a BlsctRetVal
 impl<'de, T: BlsctSerde, U> Deserialize<'de> for BlsctObj<T, U> {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where D: Deserializer<'de> {
+  where
+    D: Deserializer<'de>,
+  {
     let hex: String = Deserialize::deserialize(deserializer)?;
-    let hex_c_str = CString::new(hex)
-      .map_err(|_| DeError::custom("string contains interior NUL"))?;
+    let hex_c_str =
+      CString::new(hex).map_err(|_| DeError::custom("string contains interior NUL"))?;
 
     let rv = unsafe { T::deserialize(hex_c_str.as_ptr()) };
 
-    Ok(BlsctObj::<T, U>::from_retval(rv)
-      .map_err(|e| DeError::custom(format!("Deserialization failed: {:?}", e)))?)
+    BlsctObj::<T, U>::from_retval(rv)
+      .map_err(|e| DeError::custom(format!("Deserialization failed: {:?}", e)))
   }
 }
 
 impl<T: BlsctSerde, U> Drop for BlsctObj<T, U> {
   fn drop(&mut self) {
     match self.deallocator {
-      Some(f) => unsafe { 
-        f(self.ptr.as_ptr().cast::<c_void>())
+      Some(f) => unsafe { f(self.ptr.as_ptr().cast::<c_void>()) },
+      None => unsafe {
+        free_obj(self.ptr.as_ptr() as *mut c_void);
       },
-      None => unsafe { free_obj(self.ptr.as_ptr() as *mut c_void); },
     }
   }
 }
-

--- a/ffi/rust/src/chain.rs
+++ b/ffi/rust/src/chain.rs
@@ -1,7 +1,4 @@
-use crate::ffi::{
-  get_blsct_chain,
-  set_blsct_chain,
-};
+use crate::ffi::{get_blsct_chain, set_blsct_chain};
 use std::os::raw::c_int;
 use thiserror::Error;
 
@@ -56,7 +53,12 @@ mod tests {
 
   #[test]
   fn test_get_set_chain() {
-    for exp_chain in [Chain::Mainnet, Chain::Testnet, Chain::Signet, Chain::Regtest] {
+    for exp_chain in [
+      Chain::Mainnet,
+      Chain::Testnet,
+      Chain::Signet,
+      Chain::Regtest,
+    ] {
       Chain::set(exp_chain);
       assert_eq!(exp_chain, Chain::get());
     }
@@ -64,4 +66,3 @@ mod tests {
     Chain::set(Chain::Mainnet);
   }
 }
-

--- a/ffi/rust/src/ctx.rs
+++ b/ffi/rust/src/ctx.rs
@@ -1,44 +1,22 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ctx_id::CTxId,
   ctx_ins::CTxIns,
   ctx_outs::CTxOuts,
   ffi::{
-    add_to_tx_in_vec,
-    add_to_tx_out_vec,
-    BlsctRetVal,
-    BlsctCTx,
-    BlsctCTxId,
-    BLSCT_IN_AMOUNT_ERROR,
-    BLSCT_OUT_AMOUNT_ERROR,
-    build_ctx,
-    create_tx_in_vec,
-    create_tx_out_vec,
-    delete_ctx,
-    delete_tx_in_vec,
-    delete_tx_out_vec,
-    deserialize_ctx,
-    deserialize_ctx_id,
-    free_obj,
-    get_ctx_id,
-    get_ctx_ins,
-    get_ctx_outs,
-    serialize_ctx,
+    add_to_tx_in_vec, add_to_tx_out_vec, build_ctx, create_tx_in_vec, create_tx_out_vec,
+    delete_ctx, delete_tx_in_vec, delete_tx_out_vec, deserialize_ctx, deserialize_ctx_id, free_obj,
+    get_ctx_id, get_ctx_ins, get_ctx_outs, serialize_ctx, BlsctCTx, BlsctCTxId, BlsctRetVal,
+    BLSCT_IN_AMOUNT_ERROR, BLSCT_OUT_AMOUNT_ERROR,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-  },
+  macros::{impl_clone, impl_display},
   tx_in::TxIn,
   tx_out::TxOut,
 };
 use serde::{Deserialize, Serialize};
 use std::{
-  ffi::{
-    c_char,
-    c_void,
-  },
+  ffi::{c_char, c_void},
   fmt,
   ptr::NonNull,
 };
@@ -56,14 +34,10 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::FailedToAllocateMemory =>
-        write!(f, "Failed to allocate memory for CTx"),
-      Error::InAmountError(index) =>
-        write!(f, "Invalid in-amount found at {index}"),
-      Error::OutAmountError(index) =>
-        write!(f, "Invalid out-amount found at {index}"),
-      Error::FailedToBuildCTx(e) =>
-        write!(f, "Failed to build CTx: {e}"),
+      Error::FailedToAllocateMemory => write!(f, "Failed to allocate memory for CTx"),
+      Error::InAmountError(index) => write!(f, "Invalid in-amount found at {index}"),
+      Error::OutAmountError(index) => write!(f, "Invalid out-amount found at {index}"),
+      Error::FailedToBuildCTx(e) => write!(f, "Failed to build CTx: {e}"),
     }
   }
 }
@@ -77,10 +51,7 @@ impl_display!(CTx);
 impl_clone!(CTx);
 
 impl CTx {
-  pub fn new(
-    tx_ins: &Vec<TxIn>,
-    tx_outs: &Vec<TxOut>
-  ) -> Result<Self, Error> {
+  pub fn new(tx_ins: &Vec<TxIn>, tx_outs: &Vec<TxOut>) -> Result<Self, Error> {
     unsafe {
       let vp_tx_ins = create_tx_in_vec();
       let vp_tx_outs = create_tx_out_vec();
@@ -110,31 +81,28 @@ impl CTx {
 
         clean_up();
         Ok(obj.into())
-
       } else {
         let e = {
           match (*rv).result {
             BLSCT_IN_AMOUNT_ERROR => {
               let index = (*rv).in_amount_err_index;
               Error::InAmountError(index)
-            },
+            }
             BLSCT_OUT_AMOUNT_ERROR => {
               let index = (*rv).out_amount_err_index;
               Error::OutAmountError(index)
-            },
-            err_code => {
-              Error::FailedToBuildCTx(err_code)
             }
+            err_code => Error::FailedToBuildCTx(err_code),
           }
         };
         clean_up();
         Err(e)
-      } 
+      }
     }
   }
 
   pub fn get_ctx_id<'a>(&self) -> Result<CTxId, blsct_obj::Error<'a>> {
-    let rv = unsafe { 
+    let rv = unsafe {
       let c_str_hex = get_ctx_id(self.value());
       deserialize_ctx_id(c_str_hex)
     };
@@ -186,15 +154,9 @@ mod tests {
   use super::*;
   use crate::{
     amount_recovery_req::AmountRecoveryReq,
-    ffi::{
-      get_ctx_ins_size,
-      get_ctx_outs_size,
-    },
+    ffi::{get_ctx_ins_size, get_ctx_outs_size},
     initializer::init,
-    keys::{
-      double_public_key::DoublePublicKey,
-      public_key::PublicKey,
-    },
+    keys::{double_public_key::DoublePublicKey, public_key::PublicKey},
     range_proof::RangeProof,
     scalar::Scalar,
     sub_addr::SubAddr,
@@ -231,20 +193,12 @@ mod tests {
     init();
     let pk_view_key = PublicKey::random().unwrap();
     let pk_spend_key = PublicKey::random().unwrap();
-    let dpk = DoublePublicKey::from_view_and_spend_keys(
-      &pk_view_key,
-      &pk_spend_key,
-    ).unwrap();
+    let dpk = DoublePublicKey::from_view_and_spend_keys(&pk_view_key, &pk_spend_key).unwrap();
     let destination: SubAddr = dpk.into();
     let blinding_key = Scalar::random().unwrap();
     let out_amount = 12345;
     let msg = "space_x";
-    let ctx = gen_ctx_actual(
-      out_amount,
-      msg,
-      &destination,
-      &blinding_key,
-    );
+    let ctx = gen_ctx_actual(out_amount, msg, &destination, &blinding_key);
     let ctx_outs = ctx.get_ctx_outs();
     let ctx_outs_size = unsafe { get_ctx_outs_size(ctx_outs.value()) };
     assert_eq!(ctx_outs_size, 3);
@@ -252,8 +206,8 @@ mod tests {
 
     let rp = out0.blsct_data_range_proof().unwrap();
     let nonce = pk_view_key.get_point().scalar_multiply(&blinding_key);
-    let req = AmountRecoveryReq::new(&rp, &nonce); 
-    let amounts = RangeProof::recover_amounts(vec![req]).unwrap(); 
+    let req = AmountRecoveryReq::new(&rp, &nonce);
+    let amounts = RangeProof::recover_amounts(vec![req]).unwrap();
 
     assert_eq!(amounts.len(), 1);
     assert_eq!(amounts[0].is_succ, true);
@@ -270,4 +224,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/ctx_id.rs
+++ b/ffi/rust/src/ctx_id.rs
@@ -1,19 +1,8 @@
 use crate::{
   blsct_obj::BlsctObj,
-  blsct_serde::BlsctSerde, 
-  ffi::{
-    BlsctCTxId,
-    BlsctRetVal,
-    CTX_ID_SIZE,
-    deserialize_ctx_id,
-    serialize_ctx_id,
-  },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  blsct_serde::BlsctSerde,
+  ffi::{deserialize_ctx_id, serialize_ctx_id, BlsctCTxId, BlsctRetVal, CTX_ID_SIZE},
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   util::gen_random_malloced_buf,
 };
 use serde::{Deserialize, Serialize};
@@ -74,5 +63,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-
-

--- a/ffi/rust/src/ctx_in.rs
+++ b/ffi/rust/src/ctx_in.rs
@@ -2,14 +2,8 @@ use crate::{
   blsct_obj::BlsctObj,
   ctx_id::CTxId,
   ffi::{
-    are_ctx_in_equal,
-    BlsctCTxId,
-    BlsctScript,
-    get_ctx_in_prev_out_hash,
-    get_ctx_in_prev_out_n,
-    get_ctx_in_script_sig,
-    get_ctx_in_sequence,
-    get_ctx_in_script_witness,
+    are_ctx_in_equal, get_ctx_in_prev_out_hash, get_ctx_in_script_sig, get_ctx_in_script_witness,
+    get_ctx_in_sequence, BlsctCTxId, BlsctScript,
   },
   macros::impl_value_raw_const_obj,
   script::Script,
@@ -24,20 +18,12 @@ pub struct CTxIn {
 impl CTxIn {
   pub fn prev_out_hash(&self) -> CTxId {
     let c_obj = unsafe { get_ctx_in_prev_out_hash(self.value()) };
-    BlsctObj::<CTxId, BlsctCTxId>::from_c_obj(
-      c_obj as *mut BlsctCTxId
-    ).into()
-  }
-
-  pub fn prev_out_n(&self) -> u32 {
-    unsafe { get_ctx_in_prev_out_n(self.value()) }
+    BlsctObj::<CTxId, BlsctCTxId>::from_c_obj(c_obj as *mut BlsctCTxId).into()
   }
 
   pub fn script_sig(&self) -> Script {
     let c_obj = unsafe { get_ctx_in_script_sig(self.value()) };
-    BlsctObj::<Script, BlsctScript>::from_c_obj(
-      c_obj as *mut BlsctScript
-    ).into()
+    BlsctObj::<Script, BlsctScript>::from_c_obj(c_obj as *mut BlsctScript).into()
   }
 
   pub fn sequence(&self) -> u32 {
@@ -46,9 +32,7 @@ impl CTxIn {
 
   pub fn script_witness(&self) -> Script {
     let c_obj = unsafe { get_ctx_in_script_witness(self.value()) };
-    BlsctObj::<Script, BlsctScript>::from_c_obj(
-      c_obj as *mut BlsctScript
-    ).into()
+    BlsctObj::<Script, BlsctScript>::from_c_obj(c_obj as *mut BlsctScript).into()
   }
 
   impl_value_raw_const_obj!();
@@ -71,11 +55,8 @@ impl Eq for CTxIn {}
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    test_util::gen_ctx,
-  };
-  
+  use crate::{initializer::init, test_util::gen_ctx};
+
   fn get_ctx_in() -> CTxIn {
     let ctx = gen_ctx();
     let ctx_ins = ctx.get_ctx_ins();
@@ -88,13 +69,6 @@ mod tests {
     init();
     let ctx_in = get_ctx_in();
     let _ = ctx_in.prev_out_hash();
-  }
-
-  #[test]
-  fn test_prev_out_n() {
-    init();
-    let ctx_in = get_ctx_in();
-    let _ = ctx_in.prev_out_n();
   }
 
   #[test]
@@ -118,4 +92,3 @@ mod tests {
     let _ = ctx_in.script_witness();
   }
 }
-

--- a/ffi/rust/src/ctx_ins.rs
+++ b/ffi/rust/src/ctx_ins.rs
@@ -1,18 +1,9 @@
 use crate::{
   ctx_in::CTxIn,
-  ffi::{
-    are_ctx_ins_equal,
-    get_ctx_in_at,
-    get_ctx_ins_size,
-  },
-  macros::{
-    impl_value_raw_const_obj,
-  },
+  ffi::{are_ctx_ins_equal, get_ctx_in_at, get_ctx_ins_size},
+  macros::impl_value_raw_const_obj,
 };
-use std::{
-  ffi::c_void,
-  fmt,
-};
+use std::{ffi::c_void, fmt};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -24,14 +15,15 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::IndexOutOfRange { index, max_index } =>
-        write!(f, "Index {index} is out of range. Max index is {max_index}"),
+      Error::IndexOutOfRange { index, max_index } => {
+        write!(f, "Index {index} is out of range. Max index is {max_index}")
+      }
     }
   }
 }
 
 /* obj is an opaque pointer to:
- 
+
    struct BlsctCTxIns {
      std::vector<CTxIn>* vec;
    };
@@ -71,4 +63,3 @@ impl PartialEq for CTxIns {
     unsafe { are_ctx_ins_equal(self.value(), other.value()) }
   }
 }
-

--- a/ffi/rust/src/ctx_out.rs
+++ b/ffi/rust/src/ctx_out.rs
@@ -1,23 +1,11 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
+  blsct_obj::{self, BlsctObj},
   ffi::{
-    are_ctx_out_equal,
-    BlsctPoint,
-    BlsctRangeProof,
-    BlsctRetVal,
-    BlsctScalar,
-    BlsctScript,
-    BlsctTokenId,
+    are_ctx_out_equal, get_ctx_out_blinding_key, get_ctx_out_ephemeral_key,
+    get_ctx_out_range_proof, get_ctx_out_script_pub_key, get_ctx_out_spending_key,
+    get_ctx_out_token_id, get_ctx_out_value, get_ctx_out_vector_predicate, get_ctx_out_view_tag,
+    BlsctPoint, BlsctRangeProof, BlsctRetVal, BlsctScalar, BlsctScript, BlsctTokenId,
     BlsctVectorPredicate,
-    get_ctx_out_blinding_key,
-    get_ctx_out_ephemeral_key,
-    get_ctx_out_range_proof,
-    get_ctx_out_script_pub_key,
-    get_ctx_out_spending_key,
-    get_ctx_out_token_id,
-    get_ctx_out_value,
-    get_ctx_out_view_tag,
-    get_ctx_out_vector_predicate,
   },
   macros::impl_value_raw_const_obj,
   point::Point,
@@ -41,47 +29,37 @@ impl CTxOut {
 
   pub fn script_pub_key(&self) -> Script {
     let c_obj = unsafe { get_ctx_out_script_pub_key(self.value()) };
-    BlsctObj::<Script, BlsctScript>::from_c_obj(
-      c_obj as *mut BlsctScript
-    ).into()
+    BlsctObj::<Script, BlsctScript>::from_c_obj(c_obj as *mut BlsctScript).into()
   }
 
   pub fn token_id(&self) -> TokenId {
     let c_obj = unsafe { get_ctx_out_token_id(self.value()) };
-    BlsctObj::<TokenId, BlsctTokenId>::from_c_obj(
-      c_obj as *mut BlsctTokenId
-    ).into()
+    BlsctObj::<TokenId, BlsctTokenId>::from_c_obj(c_obj as *mut BlsctTokenId).into()
   }
 
-  pub fn vector_predicate(&self) -> Result<VectorPredicate, blsct_obj::Error> {
+  pub fn vector_predicate(&self) -> Result<VectorPredicate, blsct_obj::Error<'_>> {
     let rv = unsafe { get_ctx_out_vector_predicate(self.value()) };
     let obj = BlsctObj::<VectorPredicate, BlsctVectorPredicate>::from_retval(rv)?;
     Ok(obj.into())
   }
 
   pub fn blsct_data_spending_key(&self) -> Scalar {
-    let c_obj = unsafe { get_ctx_out_spending_key(self.value()) }; 
-    BlsctObj::<Scalar, BlsctScalar>::from_c_obj(
-      c_obj as *mut BlsctScalar
-    ).into()
+    let c_obj = unsafe { get_ctx_out_spending_key(self.value()) };
+    BlsctObj::<Scalar, BlsctScalar>::from_c_obj(c_obj as *mut BlsctScalar).into()
   }
 
   pub fn blsct_data_ephemeral_key(&self) -> Point {
-    let c_obj = unsafe { get_ctx_out_ephemeral_key(self.value()) }; 
-    BlsctObj::<Point, BlsctPoint>::from_c_obj(
-      c_obj as *mut BlsctPoint
-    ).into()
+    let c_obj = unsafe { get_ctx_out_ephemeral_key(self.value()) };
+    BlsctObj::<Point, BlsctPoint>::from_c_obj(c_obj as *mut BlsctPoint).into()
   }
 
   pub fn blsct_data_blinding_key(&self) -> Scalar {
-    let c_obj = unsafe { get_ctx_out_blinding_key(self.value()) }; 
-    BlsctObj::<Scalar, BlsctScalar>::from_c_obj(
-      c_obj as *mut BlsctScalar
-    ).into()
+    let c_obj = unsafe { get_ctx_out_blinding_key(self.value()) };
+    BlsctObj::<Scalar, BlsctScalar>::from_c_obj(c_obj as *mut BlsctScalar).into()
   }
 
-  pub fn blsct_data_range_proof(&self) -> Result<RangeProof, blsct_obj::Error> {
-    let rv = unsafe { get_ctx_out_range_proof(self.value()) } as *mut BlsctRetVal; 
+  pub fn blsct_data_range_proof(&self) -> Result<RangeProof, blsct_obj::Error<'_>> {
+    let rv = unsafe { get_ctx_out_range_proof(self.value()) } as *mut BlsctRetVal;
     let obj = BlsctObj::<RangeProof, BlsctRangeProof>::from_retval(rv)?;
     Ok(obj.into())
   }
@@ -110,11 +88,8 @@ impl Eq for CTxOut {}
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    test_util::gen_ctx,
-  };
-  
+  use crate::{initializer::init, test_util::gen_ctx};
+
   fn get_ctx_out() -> CTxOut {
     let ctx = gen_ctx();
     let ctx_outs = ctx.get_ctx_outs();
@@ -194,4 +169,3 @@ mod tests {
     println!("BlsctData.ViewTag: {view_tag}");
   }
 }
-

--- a/ffi/rust/src/ctx_outs.rs
+++ b/ffi/rust/src/ctx_outs.rs
@@ -1,18 +1,9 @@
 use crate::{
   ctx_out::CTxOut,
-  ffi::{
-    are_ctx_outs_equal,
-    get_ctx_out_at,
-    get_ctx_outs_size,
-  },
-  macros::{
-    impl_value_raw_const_obj,
-  },
+  ffi::{are_ctx_outs_equal, get_ctx_out_at, get_ctx_outs_size},
+  macros::impl_value_raw_const_obj,
 };
-use std::{
-  ffi::c_void,
-  fmt,
-};
+use std::{ffi::c_void, fmt};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -24,14 +15,15 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::IndexOutOfRange { index, max_index } =>
-        write!(f, "Index {index} is out of range. Max index is {max_index}"),
+      Error::IndexOutOfRange { index, max_index } => {
+        write!(f, "Index {index} is out of range. Max index is {max_index}")
+      }
     }
   }
 }
 
 /* obj is an opaque pointer to:
- 
+
    struct BlsctCTxOuts {
      std::vector<CTxOut>* vec;
    };
@@ -71,4 +63,3 @@ impl PartialEq for CTxOuts {
     unsafe { are_ctx_outs_equal(self.value(), other.value()) }
   }
 }
-

--- a/ffi/rust/src/ffi.rs
+++ b/ffi/rust/src/ffi.rs
@@ -1,9 +1,6 @@
 use std::{
   ffi::c_void,
-  os::raw::{
-    c_char,
-    c_int,
-  },
+  os::raw::{c_char, c_int},
 };
 
 #[repr(C)]
@@ -42,15 +39,15 @@ pub struct BlsctCTxRetVal {
 pub struct BlsctAmountRecoveryReq {
   range_proof: *mut BlsctRangeProof,
   range_proof_size: usize,
-  nonce: *mut BlsctPoint,
-  token_id: *mut BlsctTokenId,
+  nonce: BlsctPoint,
+  token_id: BlsctTokenId,
 }
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 pub struct BlsctTxIn {
   amount: u64,
-  gamma: u64,
+  gamma: BlsctScalar,
   spending_key: BlsctScalar,
   token_id: BlsctTokenId,
   out_point: BlsctOutPoint,
@@ -67,6 +64,8 @@ pub struct BlsctTxOut {
   token_id: BlsctTokenId,
   output_type: TxOutputType,
   min_stake: u64,
+  subtract_fee_from_amount: bool,
+  blinding_key: BlsctScalar,
 }
 
 #[repr(C)]
@@ -80,7 +79,7 @@ pub enum AddressEncoding {
 #[derive(Debug, PartialEq, Eq)]
 pub enum TxOutputType {
   Normal,
-  StakedCommitment
+  StakedCommitment,
 }
 
 // constants
@@ -89,7 +88,7 @@ pub const KEY_ID_SIZE: usize = 20;
 pub const POINT_SIZE: usize = 48;
 pub const PUBLIC_KEY_SIZE: usize = 48;
 pub const DOUBLE_PUBLIC_KEY_SIZE: usize = PUBLIC_KEY_SIZE * 2;
-const OUT_POINT_SIZE: usize = 36;
+const OUT_POINT_SIZE: usize = 32;
 const SUB_ADDR_SIZE: usize = DOUBLE_PUBLIC_KEY_SIZE;
 const SCALAR_SIZE: usize = 32;
 pub const SCRIPT_SIZE: usize = 28;
@@ -107,7 +106,7 @@ pub const BLSCT_OUT_AMOUNT_ERROR: u8 = 15;
 // serialized types
 pub type BlsctCTxId = [u8; CTX_ID_SIZE];
 pub type BlsctDoublePubKey = [u8; DOUBLE_PUBLIC_KEY_SIZE];
-pub type BlsctKeyId = [u8; KEY_ID_SIZE];  // = used for HashId
+pub type BlsctKeyId = [u8; KEY_ID_SIZE]; // = used for HashId
 pub type BlsctOutPoint = [u8; OUT_POINT_SIZE];
 pub type BlsctPoint = [u8; POINT_SIZE];
 pub type BlsctPubKey = [u8; PUBLIC_KEY_SIZE];
@@ -124,378 +123,355 @@ pub type BlsctVectorPredicate = u8;
 
 extern "C" {
 
-pub fn malloc(size: usize) -> *mut core::ffi::c_void;
-pub fn free_obj(x: *mut c_void);
-pub fn free_amounts_ret_val(rv: *mut BlsctAmountsRetVal);
+  pub fn malloc(size: usize) -> *mut core::ffi::c_void;
+  pub fn free_obj(x: *mut c_void);
+  pub fn free_amounts_ret_val(rv: *mut BlsctAmountsRetVal);
 
-pub fn set_blsct_chain(chain: c_int);
-pub fn get_blsct_chain() -> c_int;
+  pub fn set_blsct_chain(chain: c_int);
+  pub fn get_blsct_chain() -> c_int;
 
-// Address
-pub fn decode_address(blsct_enc_addr: *const c_char) -> *mut BlsctRetVal;
-pub fn encode_address(
-  blsct_dpk: *const BlsctDoublePubKey,
-  addr_encoding: AddressEncoding,
-) -> *mut BlsctRetVal;
+  // Address
+  pub fn decode_address(blsct_enc_addr: *const c_char) -> *mut BlsctRetVal;
+  pub fn encode_address(
+    blsct_dpk: *const BlsctDoublePubKey,
+    addr_encoding: AddressEncoding,
+  ) -> *mut BlsctRetVal;
 
-// ChildKey
-pub fn from_seed_to_child_key(seed: *const BlsctScalar) -> *mut BlsctScalar;
-pub fn from_child_key_to_blinding_key(child_key: *const BlsctScalar) -> *mut BlsctScalar;
-pub fn from_child_key_to_token_key(child_key: *const BlsctScalar) -> *mut BlsctScalar;
-pub fn from_child_key_to_tx_key(child_key: *const BlsctScalar) -> *mut BlsctScalar;
+  // ChildKey
+  pub fn from_seed_to_child_key(seed: *const BlsctScalar) -> *mut BlsctScalar;
+  pub fn from_child_key_to_blinding_key(child_key: *const BlsctScalar) -> *mut BlsctScalar;
+  pub fn from_child_key_to_token_key(child_key: *const BlsctScalar) -> *mut BlsctScalar;
+  pub fn from_child_key_to_tx_key(child_key: *const BlsctScalar) -> *mut BlsctScalar;
 
-// CTx
-pub fn create_tx_in_vec() -> *mut c_void;
-pub fn add_to_tx_in_vec(vp_tx_in_vec: *mut c_void, tx_in: *const BlsctTxIn);
-pub fn delete_tx_in_vec(vp_tx_in_vec: *mut c_void);
+  // CTx
+  pub fn create_tx_in_vec() -> *mut c_void;
+  pub fn add_to_tx_in_vec(vp_tx_in_vec: *mut c_void, tx_in: *const BlsctTxIn);
+  pub fn delete_tx_in_vec(vp_tx_in_vec: *mut c_void);
 
-pub fn create_tx_out_vec() -> *mut c_void;
-pub fn add_to_tx_out_vec(vp_tx_out_vec: *mut c_void, tx_out: *const BlsctTxOut);
-pub fn delete_tx_out_vec(vp_tx_out_vec: *mut c_void);
+  pub fn create_tx_out_vec() -> *mut c_void;
+  pub fn add_to_tx_out_vec(vp_tx_out_vec: *mut c_void, tx_out: *const BlsctTxOut);
+  pub fn delete_tx_out_vec(vp_tx_out_vec: *mut c_void);
 
-pub fn build_ctx(
-  void_tx_ins: *const c_void,
-  void_tx_outs: *const c_void,
-) -> *mut BlsctCTxRetVal;
+  pub fn build_ctx(void_tx_ins: *const c_void, void_tx_outs: *const c_void) -> *mut BlsctCTxRetVal;
 
-pub fn get_ctx_id(vp_ctx: *mut c_void) -> *const c_char;
-pub fn get_ctx_ins(vp_ctx: *mut c_void) -> *const c_void;
-pub fn get_ctx_outs(vp_ctx: *mut c_void) -> *const c_void;
-pub fn serialize_ctx(vp_ctx: *mut c_void) -> *const c_char;
-pub fn deserialize_ctx(hex: *const c_char) -> *mut BlsctRetVal;
-pub fn delete_ctx(vp_ctx: *mut c_void);
+  pub fn get_ctx_id(vp_ctx: *mut c_void) -> *const c_char;
+  pub fn get_ctx_ins(vp_ctx: *mut c_void) -> *const c_void;
+  pub fn get_ctx_outs(vp_ctx: *mut c_void) -> *const c_void;
+  pub fn serialize_ctx(vp_ctx: *mut c_void) -> *const c_char;
+  pub fn deserialize_ctx(hex: *const c_char) -> *mut BlsctRetVal;
+  pub fn delete_ctx(vp_ctx: *mut c_void);
 
-// CTxId
-pub fn serialize_ctx_id(blsct_ctx_id: *const BlsctCTxId) -> *const c_char;
-pub fn deserialize_ctx_id(hex: *const c_char) -> *mut BlsctRetVal;
+  // CTxId
+  pub fn serialize_ctx_id(blsct_ctx_id: *const BlsctCTxId) -> *const c_char;
+  pub fn deserialize_ctx_id(hex: *const c_char) -> *mut BlsctRetVal;
 
-// CTxIns
-pub fn are_ctx_ins_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
-pub fn get_ctx_ins_size(vp_ctx_ins: *const c_void) -> usize;
-pub fn get_ctx_in_at(vp_ctx_ins: *const c_void, i: usize) -> *const c_void;
+  // CTxIns
+  pub fn are_ctx_ins_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
+  pub fn get_ctx_ins_size(vp_ctx_ins: *const c_void) -> usize;
+  pub fn get_ctx_in_at(vp_ctx_ins: *const c_void, i: usize) -> *const c_void;
 
-// CTxIn
-pub fn are_ctx_in_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
-pub fn get_ctx_in_prev_out_hash(vp_ctx_in: *const c_void) -> *const BlsctCTxId;
-pub fn get_ctx_in_prev_out_n(vp_ctx_in: *const c_void) -> u32;
-pub fn get_ctx_in_script_sig(vp_ctx_in: *const c_void) -> *const BlsctScript;
-pub fn get_ctx_in_sequence(vp_ctx_in: *const c_void) -> u32;
-pub fn get_ctx_in_script_witness(vp_ctx_in: *const c_void) -> *const BlsctScript;
+  // CTxIn
+  pub fn are_ctx_in_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
+  pub fn get_ctx_in_prev_out_hash(vp_ctx_in: *const c_void) -> *const BlsctCTxId;
+  pub fn get_ctx_in_script_sig(vp_ctx_in: *const c_void) -> *const BlsctScript;
+  pub fn get_ctx_in_sequence(vp_ctx_in: *const c_void) -> u32;
+  pub fn get_ctx_in_script_witness(vp_ctx_in: *const c_void) -> *const BlsctScript;
 
-// CTxOuts
-pub fn are_ctx_outs_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
-pub fn get_ctx_outs_size(vp_ctx_outs: *const c_void) -> usize;
-pub fn get_ctx_out_at(vp_ctx_outs: *const c_void, i: usize) -> *const c_void;
+  // CTxOuts
+  pub fn are_ctx_outs_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
+  pub fn get_ctx_outs_size(vp_ctx_outs: *const c_void) -> usize;
+  pub fn get_ctx_out_at(vp_ctx_outs: *const c_void, i: usize) -> *const c_void;
 
-// CTxOut
-pub fn are_ctx_out_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
-pub fn get_ctx_out_value(vp_ctx_out: *const c_void) -> u64;
-pub fn get_ctx_out_script_pub_key(vp_ctx_out: *const c_void) -> *const BlsctScript;
-pub fn get_ctx_out_token_id(vp_ctx_out: *const c_void) -> *const BlsctTokenId;
-pub fn get_ctx_out_vector_predicate(vp_ctx_out: *const c_void) -> *mut BlsctRetVal;
+  // CTxOut
+  pub fn are_ctx_out_equal(vp_a: *const c_void, vp_b: *const c_void) -> bool;
+  pub fn get_ctx_out_value(vp_ctx_out: *const c_void) -> u64;
+  pub fn get_ctx_out_script_pub_key(vp_ctx_out: *const c_void) -> *const BlsctScript;
+  pub fn get_ctx_out_token_id(vp_ctx_out: *const c_void) -> *const BlsctTokenId;
+  pub fn get_ctx_out_vector_predicate(vp_ctx_out: *const c_void) -> *mut BlsctRetVal;
 
-// CTxOutBlsctData
-pub fn get_ctx_out_spending_key(vp_ctx_out: *const c_void) -> *const BlsctPoint;
-pub fn get_ctx_out_ephemeral_key(vp_jctx_out: *const c_void) -> *const BlsctPoint;
-pub fn get_ctx_out_blinding_key(vp_ctx_out: *const c_void) -> *const BlsctPoint;
-pub fn get_ctx_out_range_proof(vp_ctx_out: *const c_void) -> *const BlsctRetVal;
-pub fn get_ctx_out_view_tag(vp_ctx_out: *const c_void) -> u16;
+  // CTxOutBlsctData
+  pub fn get_ctx_out_spending_key(vp_ctx_out: *const c_void) -> *const BlsctPoint;
+  pub fn get_ctx_out_ephemeral_key(vp_jctx_out: *const c_void) -> *const BlsctPoint;
+  pub fn get_ctx_out_blinding_key(vp_ctx_out: *const c_void) -> *const BlsctPoint;
+  pub fn get_ctx_out_range_proof(vp_ctx_out: *const c_void) -> *const BlsctRetVal;
+  pub fn get_ctx_out_view_tag(vp_ctx_out: *const c_void) -> u16;
 
-// DoublePublicKey
-pub fn deserialize_dpk(hex: *const c_char) -> *mut BlsctRetVal;
-pub fn gen_double_pub_key(
-  blsct_pk1: *const BlsctPubKey,
-  blsct_pk2: *const BlsctPubKey,
-) -> *mut BlsctRetVal;
-pub fn serialize_dpk(blsct_dpk: *const BlsctDoublePubKey) -> *const c_char;
-pub fn gen_dpk_with_keys_acct_addr(
-  blsct_view_key: *const BlsctScalar,
-  blsct_spending_pub_key: *const BlsctPubKey,
-  account: i64,
-  address: u64,
-) -> *mut BlsctDoublePubKey;
-pub fn dpk_to_sub_addr(blsct_dpk: *const BlsctDoublePubKey) -> *mut BlsctRetVal;
+  // DoublePublicKey
+  pub fn deserialize_dpk(hex: *const c_char) -> *mut BlsctRetVal;
+  pub fn gen_double_pub_key(
+    blsct_pk1: *const BlsctPubKey,
+    blsct_pk2: *const BlsctPubKey,
+  ) -> *mut BlsctRetVal;
+  pub fn serialize_dpk(blsct_dpk: *const BlsctDoublePubKey) -> *const c_char;
+  pub fn gen_dpk_with_keys_acct_addr(
+    blsct_view_key: *const BlsctScalar,
+    blsct_spending_pub_key: *const BlsctPubKey,
+    account: i64,
+    address: u64,
+  ) -> *mut BlsctDoublePubKey;
+  pub fn dpk_to_sub_addr(blsct_dpk: *const BlsctDoublePubKey) -> *mut BlsctRetVal;
 
-// HashId
-pub fn calc_key_id(
-  blsct_blinding_pub_key: *const BlsctPubKey,
-  blsct_spending_pub_key: *const BlsctPubKey,
-  blsct_view_key: *const BlsctScalar,
-) -> *mut BlsctKeyId;
-pub fn serialize_key_id(blsct_key_id: *const BlsctKeyId) -> *const c_char;
-pub fn deserialize_key_id(hex: *const c_char) -> *mut BlsctRetVal;
+  // HashId
+  pub fn calc_key_id(
+    blsct_blinding_pub_key: *const BlsctPubKey,
+    blsct_spending_pub_key: *const BlsctPubKey,
+    blsct_view_key: *const BlsctScalar,
+  ) -> *mut BlsctKeyId;
+  pub fn serialize_key_id(blsct_key_id: *const BlsctKeyId) -> *const c_char;
+  pub fn deserialize_key_id(hex: *const c_char) -> *mut BlsctRetVal;
 
-// OutPoint
-pub fn gen_out_point(ctx_id_c_str: *const c_char, n: u32) -> *mut BlsctRetVal;
-pub fn get_out_point_n(blsct_out_point: *const BlsctOutPoint) -> u32;
-pub fn serialize_out_point(blsct_out_point: *const BlsctOutPoint) -> *const c_char;
-pub fn deserialize_out_point(hex: *const c_char) -> *mut BlsctRetVal;
+  // OutPoint
+  pub fn gen_out_point(ctx_id_c_str: *const c_char) -> *mut BlsctRetVal;
+  pub fn serialize_out_point(blsct_out_point: *const BlsctOutPoint) -> *const c_char;
+  pub fn deserialize_out_point(hex: *const c_char) -> *mut BlsctRetVal;
 
-// Point
-pub fn are_point_equal(a: *const BlsctPoint, b: *const BlsctPoint) -> c_int;
-pub fn deserialize_point(hex: *const c_char) -> *mut BlsctRetVal;
-pub fn gen_base_point() -> *mut BlsctRetVal;
-pub fn gen_random_point() -> *mut BlsctRetVal;
-pub fn is_valid_point(blsct_point: *const BlsctPoint) -> c_int;
-pub fn point_from_scalar(scalar: *const BlsctScalar) -> *mut BlsctPoint;
-pub fn serialize_point(blsct_point: *const BlsctPoint) -> *const c_char;
-pub fn scalar_muliply_point(
-  /* fix typo after next navio-core is released */
-  blsct_point: *const BlsctPoint,
-  blsct_scalar: *const BlsctScalar,
-) -> *mut BlsctPoint;
+  // Point
+  pub fn are_point_equal(a: *const BlsctPoint, b: *const BlsctPoint) -> c_int;
+  pub fn deserialize_point(hex: *const c_char) -> *mut BlsctRetVal;
+  pub fn gen_base_point() -> *mut BlsctRetVal;
+  pub fn gen_random_point() -> *mut BlsctRetVal;
+  pub fn is_valid_point(blsct_point: *const BlsctPoint) -> c_int;
+  pub fn point_from_scalar(scalar: *const BlsctScalar) -> *mut BlsctPoint;
+  pub fn serialize_point(blsct_point: *const BlsctPoint) -> *const c_char;
+  pub fn scalar_muliply_point(
+    /* fix typo after next navio-core is released */
+    blsct_point: *const BlsctPoint,
+    blsct_scalar: *const BlsctScalar,
+  ) -> *mut BlsctPoint;
 
-// PrivSpendingKey
-pub fn calc_priv_spending_key(
-  blsct_blinding_pub_key: *const BlsctPubKey,
-  blsct_view_key: *const BlsctScalar,
-  blsct_spending_key: *const BlsctScalar,
-  account: i64,
-  address: u64,
-) -> *mut BlsctScalar;
+  // PrivSpendingKey
+  pub fn calc_priv_spending_key(
+    blsct_blinding_pub_key: *const BlsctPubKey,
+    blsct_view_key: *const BlsctScalar,
+    blsct_spending_key: *const BlsctScalar,
+    account: i64,
+    address: u64,
+  ) -> *mut BlsctScalar;
 
-// PublicKey
-pub fn gen_random_public_key() -> *mut BlsctRetVal;
-pub fn get_public_key_point(pub_key: *const BlsctPubKey) -> *mut BlsctPoint;
-pub fn point_to_public_key(point: *const BlsctPoint) -> *mut BlsctPubKey;
-pub fn scalar_to_pub_key(blsct_scalar: *const BlsctScalar) -> *mut BlsctPubKey;
-pub fn calc_nonce(
-  blinding_pub_key: *const BlsctPubKey,
-  view_key: *const BlsctScalar, 
-) -> *mut BlsctPoint;
+  // PublicKey
+  pub fn gen_random_public_key() -> *mut BlsctRetVal;
+  pub fn get_public_key_point(pub_key: *const BlsctPubKey) -> *mut BlsctPoint;
+  pub fn point_to_public_key(point: *const BlsctPoint) -> *mut BlsctPubKey;
+  pub fn scalar_to_pub_key(blsct_scalar: *const BlsctScalar) -> *mut BlsctPubKey;
+  pub fn calc_nonce(
+    blinding_pub_key: *const BlsctPubKey,
+    view_key: *const BlsctScalar,
+  ) -> *mut BlsctPoint;
 
-// RangeProof
-pub fn build_range_proof(
-  vp_uint64_vec: *const c_void,
-  blsct_nonce: *const BlsctPoint,
-  blsct_msg: *const c_char,
-  blsct_token_id: *const BlsctTokenId,
-) -> *mut BlsctRetVal;
+  // RangeProof
+  pub fn build_range_proof(
+    vp_uint64_vec: *const c_void,
+    blsct_nonce: *const BlsctPoint,
+    blsct_msg: *const c_char,
+    blsct_token_id: *const BlsctTokenId,
+  ) -> *mut BlsctRetVal;
 
-pub fn verify_range_proofs(
-  vp_range_proofs: *const c_void,
-) -> *mut BlsctBoolRetVal;
+  pub fn verify_range_proofs(vp_range_proofs: *const c_void) -> *mut BlsctBoolRetVal;
 
-pub fn gen_amount_recovery_req(
-  vp_blsct_range_proof: *const c_void,
-  range_proof_size: usize,
-  vp_blsct_nonce: *const c_void,
-  vp_blsct_token_id: *const c_void,
-) -> *mut BlsctAmountRecoveryReq;
+  pub fn gen_amount_recovery_req(
+    vp_blsct_range_proof: *const c_void,
+    range_proof_size: usize,
+    vp_blsct_nonce: *const c_void,
+    vp_blsct_token_id: *const c_void,
+  ) -> *mut BlsctAmountRecoveryReq;
 
-pub fn recover_amount(
-  vp_amt_recovery_req_vec: *mut c_void
-) -> *mut BlsctAmountsRetVal;
+  pub fn recover_amount(vp_amt_recovery_req_vec: *mut c_void) -> *mut BlsctAmountsRetVal;
 
-pub fn get_range_proof_A(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctPoint;
+  pub fn get_range_proof_A(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctPoint;
 
-pub fn get_range_proof_A_wip(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctPoint;
+  pub fn get_range_proof_A_wip(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctPoint;
 
-pub fn get_range_proof_B(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctPoint;
+  pub fn get_range_proof_B(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctPoint;
 
-pub fn get_range_proof_r_prime(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctScalar;
+  pub fn get_range_proof_r_prime(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctScalar;
 
-pub fn get_range_proof_s_prime(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctScalar;
+  pub fn get_range_proof_s_prime(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctScalar;
 
-pub fn get_range_proof_delta_prime(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctScalar;
+  pub fn get_range_proof_delta_prime(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctScalar;
 
-pub fn get_range_proof_alpha_hat(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctScalar;
+  pub fn get_range_proof_alpha_hat(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctScalar;
 
-pub fn get_range_proof_tau_x(
-  blsct_range_proof: *const BlsctRangeProof,
-  range_proof_size: usize,
-) -> *mut BlsctScalar;
+  pub fn get_range_proof_tau_x(
+    blsct_range_proof: *const BlsctRangeProof,
+    range_proof_size: usize,
+  ) -> *mut BlsctScalar;
 
-pub fn serialize_range_proof(
-  blsct_range_proof: *const BlsctRangeProof,
-  obj_size: usize,
-) -> *const c_char;
+  pub fn serialize_range_proof(
+    blsct_range_proof: *const BlsctRangeProof,
+    obj_size: usize,
+  ) -> *const c_char;
 
-pub fn deserialize_range_proof(
-  hex: *const c_char,
-  obj_size: usize,
-) -> *mut BlsctRetVal;
+  pub fn deserialize_range_proof(hex: *const c_char, obj_size: usize) -> *mut BlsctRetVal;
 
-// Scalar
-pub fn deserialize_scalar(hex: *const c_char) -> *mut BlsctRetVal;
-pub fn gen_scalar(n: u64) -> *mut BlsctRetVal;
-pub fn gen_random_scalar() -> *mut BlsctRetVal;
-pub fn are_scalar_equal(a: *const BlsctScalar, b: *const BlsctScalar) -> c_int;
-pub fn scalar_to_uint64(blsct_scalar: *const BlsctScalar) -> u64;
-pub fn serialize_scalar(blsct_scalar: *const BlsctScalar) -> *const c_char;
+  // Scalar
+  pub fn deserialize_scalar(hex: *const c_char) -> *mut BlsctRetVal;
+  pub fn gen_scalar(n: u64) -> *mut BlsctRetVal;
+  pub fn gen_random_scalar() -> *mut BlsctRetVal;
+  pub fn are_scalar_equal(a: *const BlsctScalar, b: *const BlsctScalar) -> c_int;
+  pub fn scalar_to_uint64(blsct_scalar: *const BlsctScalar) -> u64;
+  pub fn serialize_scalar(blsct_scalar: *const BlsctScalar) -> *const c_char;
 
-// Script
-pub fn serialize_script(blsct_script: *const BlsctScript) -> *const c_char;
-pub fn deserialize_script(hex: *const c_char) -> *mut BlsctRetVal;
+  // Script
+  pub fn serialize_script(blsct_script: *const BlsctScript) -> *const c_char;
+  pub fn deserialize_script(hex: *const c_char) -> *mut BlsctRetVal;
 
-// Signature
-pub fn serialize_signature(blsct_signature: *const BlsctSignature) -> *const c_char;
-pub fn deserialize_signature(hex: *const c_char) -> *mut BlsctRetVal;
+  // Signature
+  pub fn serialize_signature(blsct_signature: *const BlsctSignature) -> *const c_char;
+  pub fn deserialize_signature(hex: *const c_char) -> *mut BlsctRetVal;
 
-// SubAddr
-pub fn derive_sub_address(
+  // SubAddr
+  pub fn derive_sub_address(
     blsct_view_key: *const BlsctScalar,
     blsct_spending_pub_key: *const BlsctPubKey,
     blsct_sub_addr_id: *const BlsctSubAddrId,
-) -> *mut BlsctSubAddr;
-pub fn sub_addr_to_dpk(
-  blsct_sub_addr: *const BlsctSubAddr,
-) -> *mut BlsctDoublePubKey;
-pub fn serialize_sub_addr(blsct_sub_addr: *const BlsctSignature) -> *const c_char;
-pub fn deserialize_sub_addr(hex: *const c_char) -> *mut BlsctRetVal;
+  ) -> *mut BlsctSubAddr;
+  pub fn sub_addr_to_dpk(blsct_sub_addr: *const BlsctSubAddr) -> *mut BlsctDoublePubKey;
+  pub fn serialize_sub_addr(blsct_sub_addr: *const BlsctSignature) -> *const c_char;
+  pub fn deserialize_sub_addr(hex: *const c_char) -> *mut BlsctRetVal;
 
-// SubAddrId
-pub fn gen_sub_addr_id(account: i64, address: u64) -> *mut BlsctSubAddrId;
-pub fn serialize_sub_addr_id(blsct_sub_addr_id: *const BlsctSubAddrId) -> *const c_char;
-pub fn deserialize_sub_addr_id(hex: *const c_char) -> *mut BlsctRetVal;
-pub fn get_sub_addr_id_account(blsct_sub_addr_id: *const BlsctSubAddrId) -> i64;
-pub fn get_sub_addr_id_address(blsct_sub_addr_id: *const BlsctSubAddrId) -> u64;
+  // SubAddrId
+  pub fn gen_sub_addr_id(account: i64, address: u64) -> *mut BlsctSubAddrId;
+  pub fn serialize_sub_addr_id(blsct_sub_addr_id: *const BlsctSubAddrId) -> *const c_char;
+  pub fn deserialize_sub_addr_id(hex: *const c_char) -> *mut BlsctRetVal;
+  pub fn get_sub_addr_id_account(blsct_sub_addr_id: *const BlsctSubAddrId) -> i64;
+  pub fn get_sub_addr_id_address(blsct_sub_addr_id: *const BlsctSubAddrId) -> u64;
 
-// TokenId
-pub fn gen_token_id_with_token_and_subid(token: u64, subid: u64) -> *mut BlsctRetVal;
-pub fn gen_token_id(token: u64) -> *mut BlsctRetVal;
-pub fn gen_default_token_id() -> *mut BlsctRetVal;
-pub fn get_token_id_token(blsct_token_id: *const BlsctTokenId) -> u64;
-pub fn get_token_id_subid(blsct_token_id: *const BlsctTokenId) -> u64;
-pub fn serialize_token_id(blsct_token_id: *const BlsctTokenId) -> *const c_char;
-pub fn deserialize_token_id(hex: *const c_char) -> *mut BlsctRetVal;
+  // TokenId
+  pub fn gen_token_id_with_token_and_subid(token: u64, subid: u64) -> *mut BlsctRetVal;
+  pub fn gen_token_id(token: u64) -> *mut BlsctRetVal;
+  pub fn gen_default_token_id() -> *mut BlsctRetVal;
+  pub fn get_token_id_token(blsct_token_id: *const BlsctTokenId) -> u64;
+  pub fn get_token_id_subid(blsct_token_id: *const BlsctTokenId) -> u64;
+  pub fn serialize_token_id(blsct_token_id: *const BlsctTokenId) -> *const c_char;
+  pub fn deserialize_token_id(hex: *const c_char) -> *mut BlsctRetVal;
 
-// TxIn
-pub fn build_tx_in(
-  amount: u64,
-  gamma: u64,
-  spending_key: *const BlsctScalar,
-  token_id: *const BlsctTokenId,
-  out_point: *const BlsctOutPoint,
-  staked_commitment: bool,
-  rbf: bool,
-) -> *mut BlsctRetVal;
+  // TxIn
+  pub fn build_tx_in(
+    amount: u64,
+    gamma: *const BlsctScalar,
+    spending_key: *const BlsctScalar,
+    token_id: *const BlsctTokenId,
+    out_point: *const BlsctOutPoint,
+    staked_commitment: bool,
+    rbf: bool,
+  ) -> *mut BlsctRetVal;
 
-pub fn get_tx_in_amount(tx_in: *const BlsctTxIn) -> u64;
-pub fn get_tx_in_gamma(tx_in: *const BlsctTxIn) -> u64;
-pub fn get_tx_in_spending_key(tx_in: *const BlsctTxIn) -> *mut BlsctScalar;
-pub fn get_tx_in_token_id(tx_in: *const BlsctTxIn) -> *mut BlsctTokenId;
-pub fn get_tx_in_out_point(tx_in: *const BlsctTxIn) -> *mut BlsctOutPoint;
-pub fn get_tx_in_staked_commitment(tx_in: *const BlsctTxIn) -> bool;
-pub fn get_tx_in_rbf(tx_in: *const BlsctTxIn) -> bool;
+  pub fn get_tx_in_amount(tx_in: *const BlsctTxIn) -> u64;
+  pub fn get_tx_in_gamma(tx_in: *const BlsctTxIn) -> *const BlsctScalar;
+  pub fn get_tx_in_spending_key(tx_in: *const BlsctTxIn) -> *const BlsctScalar;
+  pub fn get_tx_in_token_id(tx_in: *const BlsctTxIn) -> *const BlsctTokenId;
+  pub fn get_tx_in_out_point(tx_in: *const BlsctTxIn) -> *const BlsctOutPoint;
+  pub fn get_tx_in_staked_commitment(tx_in: *const BlsctTxIn) -> bool;
+  pub fn get_tx_in_rbf(tx_in: *const BlsctTxIn) -> bool;
 
-// TxOut
-pub fn build_tx_out(
-  blsct_dest: *const BlsctSubAddr,
-  amount: u64,
-  memo_c_str: *const c_char,
-  blsct_token_id: *const BlsctTokenId,  
-  output_type: TxOutputType,
-  min_stake: u64,
-  subtract_fee_from_amount: bool,
-  blsct_blinding_key: *const BlsctScalar,
-) -> *mut BlsctRetVal;
+  // TxOut
+  pub fn build_tx_out(
+    blsct_dest: *const BlsctSubAddr,
+    amount: u64,
+    memo_c_str: *const c_char,
+    blsct_token_id: *const BlsctTokenId,
+    output_type: TxOutputType,
+    min_stake: u64,
+    subtract_fee_from_amount: bool,
+    blsct_blinding_key: *const BlsctScalar,
+  ) -> *mut BlsctRetVal;
 
-pub fn get_tx_out_destination(tx_out: *const BlsctTxOut) -> *const BlsctSubAddr;
-pub fn get_tx_out_amount(tx_out: *const BlsctTxOut) -> u64;
-pub fn get_tx_out_memo(tx_out: *const BlsctTxOut) -> *const c_char;
-pub fn get_tx_out_token_id(tx_out: *const BlsctTxOut) -> *const BlsctTokenId;
-pub fn get_tx_out_output_type(tx_out: *const BlsctTxOut) -> TxOutputType;
-pub fn get_tx_out_min_stake(tx_out: *const BlsctTxOut) -> u64;
-pub fn get_tx_out_subtract_fee_from_amount(tx_out: *const BlsctTxOut) -> bool;
-pub fn get_tx_out_blinding_key(tx_out: *const BlsctTxOut) -> *const BlsctScalar;
+  pub fn get_tx_out_destination(tx_out: *const BlsctTxOut) -> *const BlsctSubAddr;
+  pub fn get_tx_out_amount(tx_out: *const BlsctTxOut) -> u64;
+  pub fn get_tx_out_memo(tx_out: *const BlsctTxOut) -> *const c_char;
+  pub fn get_tx_out_token_id(tx_out: *const BlsctTxOut) -> *const BlsctTokenId;
+  pub fn get_tx_out_output_type(tx_out: *const BlsctTxOut) -> TxOutputType;
+  pub fn get_tx_out_min_stake(tx_out: *const BlsctTxOut) -> u64;
+  pub fn get_tx_out_subtract_fee_from_amount(tx_out: *const BlsctTxOut) -> bool;
+  pub fn get_tx_out_blinding_key(tx_out: *const BlsctTxOut) -> *const BlsctScalar;
 
-// TxKey
-pub fn from_tx_key_to_view_key(tx_key: *const BlsctScalar) -> *mut BlsctScalar;
-pub fn from_tx_key_to_spending_key(tx_key: *const BlsctScalar) -> *mut BlsctScalar;
+  // TxKey
+  pub fn from_tx_key_to_view_key(tx_key: *const BlsctScalar) -> *mut BlsctScalar;
+  pub fn from_tx_key_to_spending_key(tx_key: *const BlsctScalar) -> *mut BlsctScalar;
 
-// VectorPredicate
-pub fn are_vector_predicate_equal(
-  a: *const BlsctVectorPredicate,
-  a_size: usize,
-  b: *const BlsctVectorPredicate,
-  b_size: usize,
-) -> c_int;
+  // VectorPredicate
+  pub fn are_vector_predicate_equal(
+    a: *const BlsctVectorPredicate,
+    a_size: usize,
+    b: *const BlsctVectorPredicate,
+    b_size: usize,
+  ) -> c_int;
 
-pub fn serialize_vector_predicate(
-  blsct_vector_predicate: *const BlsctVectorPredicate,
-  obj_size: usize,
-) -> *const c_char;
+  pub fn serialize_vector_predicate(
+    blsct_vector_predicate: *const BlsctVectorPredicate,
+    obj_size: usize,
+  ) -> *const c_char;
 
-pub fn deserialize_vector_predicate(
-  hex: *const c_char,
-) -> *mut BlsctRetVal;
+  pub fn deserialize_vector_predicate(hex: *const c_char) -> *mut BlsctRetVal;
 
-// ViewTag
-pub fn calc_view_tag(
-  blinding_pub_key: *const BlsctPubKey,
-  view_key: *const BlsctScalar,
-) -> u64;
+  // ViewTag
+  pub fn calc_view_tag(blinding_pub_key: *const BlsctPubKey, view_key: *const BlsctScalar) -> u64;
 
-// Misc helper functions
-pub fn succ(value: *mut c_void, value_size: usize) -> *mut BlsctRetVal;
-pub fn err_bool(result: u8) -> *mut BlsctRetVal;
-pub fn hex_to_malloced_buf(hex: *const c_char) -> *mut u8;
-pub fn buf_to_malloced_hex_c_str(buf: *const u8, size: usize) -> *const c_char;
+  // Misc helper functions
+  pub fn succ(value: *mut c_void, value_size: usize) -> *mut BlsctRetVal;
+  pub fn err_bool(result: u8) -> *mut BlsctRetVal;
+  pub fn hex_to_malloced_buf(hex: *const c_char) -> *mut u8;
+  pub fn buf_to_malloced_hex_c_str(buf: *const u8, size: usize) -> *const c_char;
 
-// uint64 vector
-pub fn create_uint64_vec() -> *mut c_void;
-pub fn add_to_uint64_vec(vp_uint64_vec: *mut c_void, n: u64);
-pub fn delete_uint64_vec(vp_vec: *mut c_void);
+  // uint64 vector
+  pub fn create_uint64_vec() -> *mut c_void;
+  pub fn add_to_uint64_vec(vp_uint64_vec: *mut c_void, n: u64);
+  pub fn delete_uint64_vec(vp_vec: *mut c_void);
 
-// range proof vector
-pub fn create_range_proof_vec() -> *mut c_void;
-pub fn add_to_range_proof_vec(
-  vp_range_proofs: *mut c_void,
-  blsct_range_proof: *const BlsctRangeProof,
-  blsct_range_proof_size: usize,
-);
-pub fn delete_range_proof_vec(vp_range_proofs: *const c_void);
+  // range proof vector
+  pub fn create_range_proof_vec() -> *mut c_void;
+  pub fn add_to_range_proof_vec(
+    vp_range_proofs: *mut c_void,
+    blsct_range_proof: *const BlsctRangeProof,
+    blsct_range_proof_size: usize,
+  );
+  pub fn delete_range_proof_vec(vp_range_proofs: *const c_void);
 
-// amount recovery request vector
-pub fn create_amount_recovery_req_vec() -> *mut c_void;
+  // amount recovery request vector
+  pub fn create_amount_recovery_req_vec() -> *mut c_void;
 
-pub fn add_to_amount_recovery_req_vec(
-  vp_amt_recovery_req_vec: *mut c_void,
-  vp_amt_recovery_req: *mut c_void,
-);
+  pub fn add_to_amount_recovery_req_vec(
+    vp_amt_recovery_req_vec: *mut c_void,
+    vp_amt_recovery_req: *mut c_void,
+  );
 
-pub fn delete_amount_recovery_req_vec(vp_amt_recovery_req_vec: *mut c_void);
+  pub fn delete_amount_recovery_req_vec(vp_amt_recovery_req_vec: *mut c_void);
 
-pub fn get_amount_recovery_result_size(
-  vp_amt_recovery_res_vec: *mut c_void
-) -> i16;
+  pub fn get_amount_recovery_result_size(vp_amt_recovery_res_vec: *mut c_void) -> usize;
 
-pub fn get_amount_recovery_result_is_succ(
-  vp_amt_recovery_req_vec: *mut c_void,
-  idx: usize,
-) -> bool;
+  pub fn get_amount_recovery_result_is_succ(
+    vp_amt_recovery_req_vec: *mut c_void,
+    idx: usize,
+  ) -> bool;
 
-pub fn get_amount_recovery_result_amount(
-  vp_amt_recovery_req_vec: *mut c_void,
-  idx: usize,
-) -> u64;
+  pub fn get_amount_recovery_result_amount(vp_amt_recovery_req_vec: *mut c_void, idx: usize)
+    -> u64;
 
-pub fn get_amount_recovery_result_msg(
-  vp_amt_recovery_req_vec: *mut c_void,
-  idx: usize,
-) -> *const c_char;
+  pub fn get_amount_recovery_result_msg(
+    vp_amt_recovery_req_vec: *mut c_void,
+    idx: usize,
+  ) -> *const c_char;
 
 } // extern "C"
 
@@ -506,18 +482,16 @@ mod tests {
 
   #[test]
   fn test_hex_to_malloced_buf() {
-    let test = |hex: &str| {
-      unsafe {
-        let hex_cstring = CString::new(hex).unwrap();
-        let bytes_buf = hex_to_malloced_buf(hex_cstring.as_ptr());
-        let hex_buf = buf_to_malloced_hex_c_str(bytes_buf, hex.len() / 2);
-        let rec_hex = CStr::from_ptr(hex_buf).to_str().unwrap();
+    let test = |hex: &str| unsafe {
+      let hex_cstring = CString::new(hex).unwrap();
+      let bytes_buf = hex_to_malloced_buf(hex_cstring.as_ptr());
+      let hex_buf = buf_to_malloced_hex_c_str(bytes_buf, hex.len() / 2);
+      let rec_hex = CStr::from_ptr(hex_buf).to_str().unwrap();
 
-        assert_eq!(hex, rec_hex);
+      assert_eq!(hex, rec_hex);
 
-        free_obj(bytes_buf as *mut c_void);
-        free_obj(hex_buf as *mut c_void);
-      }
+      free_obj(bytes_buf as *mut c_void);
+      free_obj(hex_buf as *mut c_void);
     };
     for n in (1u32..=0xFFFF).step_by(3) {
       let hex = format!("{:04x}", n);

--- a/ffi/rust/src/hash_id.rs
+++ b/ffi/rust/src/hash_id.rs
@@ -1,23 +1,9 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
-  ffi::{
-    BlsctKeyId,
-    BlsctRetVal,
-    calc_key_id,
-    deserialize_key_id,
-    serialize_key_id,
-  },
-  keys::{
-    child_key::ChildKey,
-    public_key::PublicKey,
-  },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
+  ffi::{calc_key_id, deserialize_key_id, serialize_key_id, BlsctKeyId, BlsctRetVal},
+  keys::{child_key::ChildKey, public_key::PublicKey},
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   scalar::Scalar,
 };
 use serde::{Deserialize, Serialize};
@@ -38,11 +24,13 @@ impl HashId {
     spending_pub_key: &PublicKey,
     view_key: &Scalar,
   ) -> Self {
-    let blsct_key_id = unsafe { calc_key_id(
-      blinding_pub_key.value(),
-      spending_pub_key.value(),
-      view_key.value(),
-    )};
+    let blsct_key_id = unsafe {
+      calc_key_id(
+        blinding_pub_key.value(),
+        spending_pub_key.value(),
+        view_key.value(),
+      )
+    };
     BlsctObj::from_c_obj(blsct_key_id).into()
   }
 
@@ -51,13 +39,9 @@ impl HashId {
     let spending_pub_key = PublicKey::random()?;
     let view_key = {
       let child_key = ChildKey::random()?;
-      child_key.to_tx_key().to_view_key() 
+      child_key.to_tx_key().to_view_key()
     };
-    Ok(Self::new(
-      &blinding_pub_key,
-      &spending_pub_key,
-      &view_key,
-    ))
+    Ok(Self::new(&blinding_pub_key, &spending_pub_key, &view_key))
   }
 
   impl_value!(BlsctKeyId);
@@ -75,7 +59,7 @@ impl BlsctSerde for HashId {
 
 impl PartialEq for HashId {
   fn eq(&self, other: &Self) -> bool {
-    self.obj == other.obj 
+    self.obj == other.obj
   }
 }
 
@@ -117,4 +101,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/initializer.rs
+++ b/ffi/rust/src/initializer.rs
@@ -2,8 +2,8 @@ use std::sync::Once;
 
 extern "C" {
 
-#[link_name = "init"]
-pub fn init_impl();  // rename on the rust side to avoid name conflict
+  #[link_name = "init"]
+  pub fn init_impl(); // rename on the rust side to avoid name conflict
 
 }
 
@@ -24,4 +24,3 @@ mod tests {
     init();
   }
 }
-

--- a/ffi/rust/src/keys/child_key.rs
+++ b/ffi/rust/src/keys/child_key.rs
@@ -1,14 +1,11 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
+  blsct_obj::{self, BlsctObj},
   ffi::{
-    BlsctScalar,
-    from_child_key_to_blinding_key,
-    from_child_key_to_token_key,
-    from_child_key_to_tx_key,
-    from_seed_to_child_key,
+    from_child_key_to_blinding_key, from_child_key_to_token_key, from_child_key_to_tx_key,
+    from_seed_to_child_key, BlsctScalar,
   },
-  scalar::Scalar,
   keys::tx_key::TxKey,
+  scalar::Scalar,
 };
 use serde::{Deserialize, Serialize};
 
@@ -100,4 +97,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/keys/double_public_key.rs
+++ b/ffi/rust/src/keys/double_public_key.rs
@@ -1,27 +1,17 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
+  blsct_obj::{self, BlsctObj},
   blsct_serde::BlsctSerde,
   ffi::{
-    BlsctDoublePubKey,
-    BlsctRetVal,
-    deserialize_dpk,
-    gen_double_pub_key,
-    gen_dpk_with_keys_acct_addr,
-    serialize_dpk,
-    sub_addr_to_dpk,
+    deserialize_dpk, gen_double_pub_key, gen_dpk_with_keys_acct_addr, serialize_dpk,
+    sub_addr_to_dpk, BlsctDoublePubKey, BlsctRetVal,
   },
   keys::public_key::PublicKey,
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   scalar::Scalar,
   sub_addr::SubAddr,
 };
-use std::ffi::c_char;
 use serde::{Deserialize, Serialize};
+use std::ffi::c_char;
 
 #[derive(PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct DoublePublicKey {
@@ -53,9 +43,7 @@ impl DoublePublicKey {
     view_key: &PublicKey,
     spend_key: &PublicKey,
   ) -> Result<Self, blsct_obj::Error<'a>> {
-    let rv = unsafe {
-      gen_double_pub_key(view_key.value(), spend_key.value())
-    };
+    let rv = unsafe { gen_double_pub_key(view_key.value(), spend_key.value()) };
     let obj = BlsctObj::from_retval(rv)?;
     Ok(obj.into())
   }
@@ -67,18 +55,13 @@ impl DoublePublicKey {
     address: u64,
   ) -> Self {
     let dpk = unsafe {
-      gen_dpk_with_keys_acct_addr(
-        view_key.value(),
-        spending_pub_key.value(),
-        account,
-        address,
-      )
+      gen_dpk_with_keys_acct_addr(view_key.value(), spending_pub_key.value(), account, address)
     };
     let obj = BlsctObj::from_c_obj(dpk);
     obj.into()
   }
 
-  pub fn random<'a>() -> Result<Self, blsct_obj::Error<'a>> { 
+  pub fn random<'a>() -> Result<Self, blsct_obj::Error<'a>> {
     let view_key = PublicKey::random()?;
     let spend_key = PublicKey::random()?;
     Self::from_view_and_spend_keys(&view_key, &spend_key)
@@ -98,10 +81,7 @@ impl BlsctSerde for DoublePublicKey {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    keys::child_key::ChildKey,
-  };
+  use crate::{initializer::init, keys::child_key::ChildKey};
 
   #[test]
   fn test_random() {
@@ -114,8 +94,7 @@ mod tests {
     init();
     let a = PublicKey::random().unwrap();
     let b = PublicKey::random().unwrap();
-    let _: DoublePublicKey = 
-      DoublePublicKey::from_view_and_spend_keys(&a, &b).unwrap();
+    let _: DoublePublicKey = DoublePublicKey::from_view_and_spend_keys(&a, &b).unwrap();
   }
 
   #[test]
@@ -126,12 +105,7 @@ mod tests {
     let view_key = tx_key.to_view_key();
     let pub_key = PublicKey::random().unwrap();
 
-    DoublePublicKey::from_keys_acct_addr(
-      &view_key,
-      &pub_key,
-      123,
-      456,
-    );
+    DoublePublicKey::from_keys_acct_addr(&view_key, &pub_key, 123, 456);
   }
 
   #[test]

--- a/ffi/rust/src/keys/mod.rs
+++ b/ffi/rust/src/keys/mod.rs
@@ -3,4 +3,3 @@ pub mod double_public_key;
 pub mod priv_spending_key;
 pub mod public_key;
 pub mod tx_key;
-

--- a/ffi/rust/src/keys/priv_spending_key.rs
+++ b/ffi/rust/src/keys/priv_spending_key.rs
@@ -1,7 +1,4 @@
-use crate::{
-  ffi::calc_priv_spending_key,
-  keys::public_key::PublicKey,
-};
+use crate::{ffi::calc_priv_spending_key, keys::public_key::PublicKey};
 
 crate::macros::impl_key!(PrivSpendingKey);
 
@@ -30,10 +27,7 @@ impl PrivSpendingKey {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    keys::child_key::ChildKey,
-  };
+  use crate::{initializer::init, keys::child_key::ChildKey};
 
   #[test]
   fn test_new() {
@@ -44,12 +38,7 @@ mod tests {
     let spending_key = tx_key.to_spending_key();
     let blinding_pub_key = PublicKey::random().unwrap();
 
-    let _: PrivSpendingKey = PrivSpendingKey::new(
-      blinding_pub_key,
-      view_key,
-      spending_key,
-      123,
-      456,
-    );
+    let _: PrivSpendingKey =
+      PrivSpendingKey::new(blinding_pub_key, view_key, spending_key, 123, 456);
   }
 }

--- a/ffi/rust/src/keys/public_key.rs
+++ b/ffi/rust/src/keys/public_key.rs
@@ -1,34 +1,17 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ffi::{
-    BLSCT_FAILURE,
-    BlsctPubKey,
-    BlsctRetVal,
-    calc_nonce,
-    err_bool,
-    gen_random_public_key,
-    get_public_key_point,
-    point_to_public_key,
-    PUBLIC_KEY_SIZE,
-    scalar_to_pub_key,
-    serialize_point,
+    calc_nonce, err_bool, gen_random_public_key, get_public_key_point, point_to_public_key,
+    scalar_to_pub_key, serialize_point, BlsctPubKey, BlsctRetVal, BLSCT_FAILURE, PUBLIC_KEY_SIZE,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   point::Point,
   scalar::Scalar,
-  util::{
-    c_hex_str_to_array,
-    build_succ_blsct_ret_val,
-  },
+  util::{build_succ_blsct_ret_val, c_hex_str_to_array},
 };
-use std::ffi::c_char;
 use serde::{Deserialize, Serialize};
+use std::ffi::c_char;
 
 #[derive(PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct PublicKey {
@@ -45,9 +28,7 @@ impl PublicKey {
   }
 
   pub fn generate_nonce(&self, view_key: &Scalar) -> Self {
-    let blsct_point = unsafe {
-      calc_nonce(self.value(), view_key.value())
-    };
+    let blsct_point = unsafe { calc_nonce(self.value(), view_key.value()) };
     let obj = BlsctObj::from_c_obj(blsct_point);
     let point: Point = obj.into();
     (&point).into()
@@ -70,7 +51,7 @@ impl BlsctSerde for PublicKey {
   }
 
   unsafe fn deserialize(hex: *const c_char) -> *mut BlsctRetVal {
-    // since hex is a serialized Point, convert it back to BlsctPoint 
+    // since hex is a serialized Point, convert it back to BlsctPoint
     match c_hex_str_to_array(hex) {
       Ok(buf) => {
         let blsct_pub_key = unsafe { point_to_public_key(&buf) };
@@ -78,10 +59,8 @@ impl BlsctSerde for PublicKey {
           Ok(rv) => rv,
           Err(_) => err_bool(BLSCT_FAILURE),
         }
-      },
-      Err(_) => {
-        err_bool(BLSCT_FAILURE)
-      },
+      }
+      Err(_) => err_bool(BLSCT_FAILURE),
     }
   }
 }
@@ -119,10 +98,7 @@ impl From<&Scalar> for PublicKey {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    keys::child_key::ChildKey,
-  };
+  use crate::{initializer::init, keys::child_key::ChildKey};
 
   #[test]
   fn test_random() {
@@ -188,4 +164,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/keys/tx_key.rs
+++ b/ffi/rust/src/keys/tx_key.rs
@@ -1,7 +1,4 @@
-use crate::ffi::{
-  from_tx_key_to_spending_key,
-  from_tx_key_to_view_key,
-};
+use crate::ffi::{from_tx_key_to_spending_key, from_tx_key_to_view_key};
 
 crate::macros::impl_key!(TxKey);
 
@@ -22,10 +19,7 @@ impl TxKey {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    keys::child_key::ChildKey,
-  };
+  use crate::{initializer::init, keys::child_key::ChildKey};
 
   fn get_tx_key() -> TxKey {
     init();
@@ -47,4 +41,3 @@ mod tests {
     tx_key.to_view_key();
   }
 }
-

--- a/ffi/rust/src/macros.rs
+++ b/ffi/rust/src/macros.rs
@@ -23,7 +23,8 @@ macro_rules! impl_from_retval {
 
 macro_rules! impl_size {
   () => {
-    #[inline] pub fn size(&self) -> usize {
+    #[inline]
+    pub fn size(&self) -> usize {
       self.obj.size()
     }
   };
@@ -31,7 +32,8 @@ macro_rules! impl_size {
 
 macro_rules! impl_value {
   ($t:ident) => {
-    #[inline] pub fn value(&self) -> *const $t {
+    #[inline]
+    pub fn value(&self) -> *const $t {
       self.obj.as_ptr()
     }
   };
@@ -39,7 +41,8 @@ macro_rules! impl_value {
 
 macro_rules! impl_value_raw_const_obj {
   () => {
-    #[inline] pub fn value(&self) -> *const c_void {
+    #[inline]
+    pub fn value(&self) -> *const c_void {
       self.obj
     }
   };
@@ -53,16 +56,12 @@ macro_rules! impl_clone {
         bincode::deserialize::<$name>(&hex).unwrap()
       }
     }
-  }
+  };
 }
 
 macro_rules! impl_key {
   ($name:ident) => {
-    use crate::{
-      blsct_obj::BlsctObj,
-      ffi::BlsctScalar,
-      scalar::Scalar,
-    };
+    use crate::{blsct_obj::BlsctObj, ffi::BlsctScalar, scalar::Scalar};
     use serde::{Deserialize, Serialize};
 
     #[derive(PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -96,4 +95,3 @@ pub(crate) use impl_key;
 pub(crate) use impl_size;
 pub(crate) use impl_value;
 pub(crate) use impl_value_raw_const_obj;
-

--- a/ffi/rust/src/out_point.rs
+++ b/ffi/rust/src/out_point.rs
@@ -1,21 +1,9 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ctx_id::CTxId,
-  ffi::{
-    BlsctOutPoint,
-    BlsctRetVal,
-    deserialize_out_point,
-    gen_out_point,
-    get_out_point_n,
-    serialize_out_point,
-  },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  ffi::{deserialize_out_point, gen_out_point, serialize_out_point, BlsctOutPoint, BlsctRetVal},
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
 };
 use serde::{Deserialize, Serialize};
 use std::ffi::c_char;
@@ -30,14 +18,10 @@ impl_display!(OutPoint);
 impl_clone!(OutPoint);
 
 impl OutPoint {
-  pub fn new<'a>(ctx_id: &CTxId, index: u32) -> Result<Self, blsct_obj::Error<'a>> {
-    let rv = unsafe { gen_out_point(ctx_id.value() as *const c_char, index) };
+  pub fn new<'a>(ctx_id: &CTxId) -> Result<Self, blsct_obj::Error<'a>> {
+    let rv = unsafe { gen_out_point(ctx_id.value() as *const c_char) };
     let obj = BlsctObj::from_retval(rv)?;
     Ok(obj.into())
-  }
-
-  pub fn index(&self) -> u32 {
-    unsafe { get_out_point_n(self.value()) }
   }
 
   impl_value!(BlsctOutPoint);
@@ -55,9 +39,7 @@ impl BlsctSerde for OutPoint {
 
 impl PartialEq for OutPoint {
   fn eq(&self, other: &Self) -> bool {
-    let self_n = unsafe { get_out_point_n(self.value()) };
-    let other_n = unsafe { get_out_point_n(other.value()) };
-    self.obj == other.obj && self_n == other_n
+    self.obj == other.obj
   }
 }
 
@@ -70,29 +52,15 @@ impl From<BlsctObj<OutPoint, BlsctOutPoint>> for OutPoint {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    ctx_id::CTxId,
-    initializer::init,
-  };
-
-  #[test]
-  fn test_index() {
-    init();
-    let ctx_id = CTxId::random();
-    let index = 3;
-    let a = OutPoint::new(&ctx_id, index).unwrap();
-    assert_eq!(a.index(), 3);
-  }
+  use crate::{ctx_id::CTxId, initializer::init};
 
   #[test]
   fn test_deser() {
     init();
     let ctx_id = CTxId::random();
-    let index = 3;
-    let a = OutPoint::new(&ctx_id, index).unwrap();
+    let a = OutPoint::new(&ctx_id).unwrap();
     let hex = bincode::serialize(&a).unwrap();
     let b = bincode::deserialize::<OutPoint>(&hex).unwrap();
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/point.rs
+++ b/ffi/rust/src/point.rs
@@ -1,26 +1,13 @@
+use crate::macros::{impl_clone, impl_display, impl_from_retval, impl_value};
+use crate::scalar::Scalar;
 use crate::{
-  blsct_obj::{BlsctObj, self},
+  blsct_obj::{self, BlsctObj},
   blsct_serde::BlsctSerde,
   ffi::{
-    are_point_equal,
-    BlsctPoint,
-    BlsctRetVal,
-    deserialize_point,
-    gen_base_point,
-    gen_random_point,
-    is_valid_point,
-    point_from_scalar,
-    scalar_muliply_point,
-    serialize_point,
+    are_point_equal, deserialize_point, gen_base_point, gen_random_point, is_valid_point,
+    point_from_scalar, scalar_muliply_point, serialize_point, BlsctPoint, BlsctRetVal,
   },
 };
-use crate::macros::{
-  impl_clone,
-  impl_display,
-  impl_from_retval,
-  impl_value,
-};
-use crate::scalar::Scalar;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -43,7 +30,7 @@ impl Point {
 
   pub fn is_valid(&self) -> bool {
     let b = unsafe { is_valid_point(self.obj.as_ptr()) };
-    return b != 0;
+    b != 0
   }
 
   pub fn scalar_multiply(&self, n: &Scalar) -> Self {
@@ -84,10 +71,12 @@ impl BlsctSerde for Point {
 
 impl PartialEq for Point {
   fn eq(&self, other: &Self) -> bool {
-    unsafe { are_point_equal(
-      self.obj.as_ptr() as *const BlsctPoint,
-      other.obj.as_ptr() as *const BlsctPoint
-    ) != 0 }
+    unsafe {
+      are_point_equal(
+        self.obj.as_ptr() as *const BlsctPoint,
+        other.obj.as_ptr() as *const BlsctPoint,
+      ) != 0
+    }
   }
 }
 
@@ -114,7 +103,7 @@ mod tests {
 
     for _ in 0..1000 {
       let x = Point::random().unwrap();
-      
+
       if prev == x {
         dup_tolerance -= 1;
         if dup_tolerance == 0 {
@@ -169,4 +158,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/range_proof.rs
+++ b/ffi/rust/src/range_proof.rs
@@ -1,63 +1,28 @@
 use crate::{
   amount_recovery_req::AmountRecoveryReq,
   amount_recovery_res::AmountRecoveryRes,
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ffi::{
-    add_to_amount_recovery_req_vec,
-    add_to_uint64_vec,
-    add_to_range_proof_vec,
-    BlsctPoint,
-    BlsctRangeProof,
-    BlsctRetVal,
-    BlsctScalar,
-    build_range_proof,
-    create_amount_recovery_req_vec,
-    create_range_proof_vec,
-    create_uint64_vec,
-    delete_amount_recovery_req_vec,
-    delete_range_proof_vec,
-    delete_uint64_vec,
-    deserialize_range_proof,
-    free_obj,
-    free_amounts_ret_val,
-    gen_amount_recovery_req,
-    get_amount_recovery_result_amount,
-    get_amount_recovery_result_is_succ,
-    get_amount_recovery_result_msg,
-    get_amount_recovery_result_size,
-    get_range_proof_A,
-    get_range_proof_A_wip,
-    get_range_proof_B,
-    get_range_proof_r_prime,
-    get_range_proof_s_prime,
-    get_range_proof_delta_prime,
-    get_range_proof_alpha_hat,
-    get_range_proof_tau_x,
-    recover_amount,
-    serialize_range_proof,
-    verify_range_proofs,
+    add_to_amount_recovery_req_vec, add_to_range_proof_vec, add_to_uint64_vec, build_range_proof,
+    create_amount_recovery_req_vec, create_range_proof_vec, create_uint64_vec,
+    delete_amount_recovery_req_vec, delete_range_proof_vec, delete_uint64_vec,
+    deserialize_range_proof, free_amounts_ret_val, free_obj, gen_amount_recovery_req,
+    get_amount_recovery_result_amount, get_amount_recovery_result_is_succ,
+    get_amount_recovery_result_msg, get_amount_recovery_result_size, get_range_proof_A,
+    get_range_proof_A_wip, get_range_proof_B, get_range_proof_alpha_hat,
+    get_range_proof_delta_prime, get_range_proof_r_prime, get_range_proof_s_prime,
+    get_range_proof_tau_x, recover_amount, serialize_range_proof, verify_range_proofs, BlsctPoint,
+    BlsctRangeProof, BlsctRetVal, BlsctScalar,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_size,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_size, impl_value},
   point::Point,
   scalar::Scalar,
   token_id::TokenId,
 };
 use serde::{Deserialize, Serialize};
 use std::{
-  ffi::{
-    CStr,
-    CString,
-    c_char,
-    c_void,
-    NulError,
-  },
+  ffi::{c_char, c_void, CStr, CString, NulError},
   fmt,
 };
 
@@ -78,22 +43,18 @@ impl<'a> std::error::Error for Error<'a> {}
 impl<'a> fmt::Display for Error<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::BlsctObjError(e) =>
-        write!(f, "BlsctObjError: {e:?}"),
-      Error::FailedToCreateUint64Vec =>
-        write!(f, "Failed to create uint64_t vector"),
-      Error::FailedToCreateCString(e) =>
-        write!(f, "Failed to create CString: {e:?}"),
-      Error::FailedToCreateRangeProofVector =>
-        write!(f, "Failed to create range proof vector"),
-      Error::FailedToVerifyRangeProofs(e) =>
-        write!(f, "Failed to verify range proofs: {e}"),
-      Error::FailedToCreateAmountRecoveryRequestVector =>
-        write!(f, "Failed to create amount recovery request vector"),
-      Error::FailedToCreateDefaultTokenId =>
-        write!(f, "Failed to create default token id"),
-      Error::FailedToRecoverAmount(e) =>
-        write!(f, "Failed to recover amount: {e}"),
+      Error::BlsctObjError(e) => write!(f, "BlsctObjError: {e:?}"),
+      Error::FailedToCreateUint64Vec => write!(f, "Failed to create uint64_t vector"),
+      Error::FailedToCreateCString(e) => write!(f, "Failed to create CString: {e:?}"),
+      Error::FailedToCreateRangeProofVector => {
+        write!(f, "Failed to create range proof vector")
+      }
+      Error::FailedToVerifyRangeProofs(e) => write!(f, "Failed to verify range proofs: {e}"),
+      Error::FailedToCreateAmountRecoveryRequestVector => {
+        write!(f, "Failed to create amount recovery request vector")
+      }
+      Error::FailedToCreateDefaultTokenId => write!(f, "Failed to create default token id"),
+      Error::FailedToRecoverAmount(e) => write!(f, "Failed to recover amount: {e}"),
     }
   }
 }
@@ -112,7 +73,7 @@ impl RangeProof {
     amounts: &Vec<u64>,
     nonce: &Point,
     msg: &str,
-    token_id: &TokenId
+    token_id: &TokenId,
   ) -> Result<Self, Error<'a>> {
     let vp_u64_vec = {
       let vec = unsafe { create_uint64_vec() };
@@ -124,19 +85,13 @@ impl RangeProof {
       }
       vec
     };
-    let c_msg = CString::new(msg)
-      .map_err(|e| Error::FailedToCreateCString(e))?;
+    let c_msg = CString::new(msg).map_err(Error::FailedToCreateCString)?;
 
-    let rv = unsafe { build_range_proof(
-      vp_u64_vec,
-      nonce.value(),
-      c_msg.as_ptr(),
-      token_id.value(),
-    )};
+    let rv =
+      unsafe { build_range_proof(vp_u64_vec, nonce.value(), c_msg.as_ptr(), token_id.value()) };
     unsafe { delete_uint64_vec(vp_u64_vec) };
 
-    let obj = BlsctObj::from_retval(rv)
-      .map_err(|e| Error::BlsctObjError(e))?;
+    let obj = BlsctObj::from_retval(rv).map_err(Error::BlsctObjError)?;
     Ok(obj.into())
   }
 
@@ -148,21 +103,17 @@ impl RangeProof {
 
     for proof in proofs {
       let proof_size = proof.obj.size();
-      unsafe { add_to_range_proof_vec(
-        range_proofs,
-        proof.value(),
-        proof_size,
-      )};
+      unsafe { add_to_range_proof_vec(range_proofs, proof.value(), proof_size) };
     }
 
     let rv = unsafe { verify_range_proofs(range_proofs) };
     let (result, value) = unsafe { ((*rv).result, (*rv).value) };
-    unsafe { 
+    unsafe {
       delete_range_proof_vec(range_proofs);
       free_obj(rv as *mut c_void);
     };
 
-    if result == 0 { 
+    if result == 0 {
       Ok(value)
     } else {
       Err(Error::FailedToVerifyRangeProofs(result))
@@ -172,7 +123,6 @@ impl RangeProof {
   pub fn recover_amounts<'a>(
     reqs: Vec<AmountRecoveryReq>,
   ) -> Result<Vec<AmountRecoveryRes>, Error<'a>> {
-
     let req_vec = unsafe { create_amount_recovery_req_vec() };
     if req_vec.is_null() {
       return Err(Error::FailedToCreateAmountRecoveryRequestVector);
@@ -185,17 +135,16 @@ impl RangeProof {
       };
       let token_id = req.token_id.as_ref().or(default_token_id.as_ref()).unwrap();
 
-      let blsct_req = unsafe { gen_amount_recovery_req(
-        req.range_proof.value() as *mut c_void,
-        req.range_proof.size(),
-        req.nonce.value() as *mut c_void,
-        token_id.value() as *mut c_void,
-      )};
+      let blsct_req = unsafe {
+        gen_amount_recovery_req(
+          req.range_proof.value() as *mut c_void,
+          req.range_proof.size(),
+          req.nonce.value() as *mut c_void,
+          token_id.value() as *mut c_void,
+        )
+      };
 
-      unsafe { add_to_amount_recovery_req_vec(
-        req_vec,
-        blsct_req as *mut c_void,
-      )};
+      unsafe { add_to_amount_recovery_req_vec(req_vec, blsct_req as *mut c_void) };
     }
 
     let rv = unsafe { recover_amount(req_vec) };
@@ -214,14 +163,12 @@ impl RangeProof {
       let is_succ = unsafe { get_amount_recovery_result_is_succ(value, i) };
       let amount = unsafe { get_amount_recovery_result_amount(value, i) };
       let msg_c_str = unsafe { get_amount_recovery_result_msg(value, i) };
-      let msg = if msg_c_str.is_null() { "" } else {
+      let msg = if msg_c_str.is_null() {
+        ""
+      } else {
         unsafe { CStr::from_ptr(msg_c_str) }.to_str().unwrap()
       };
-      let result = AmountRecoveryRes::new(
-        is_succ,
-        amount,
-        &msg,
-      );
+      let result = AmountRecoveryRes::new(is_succ, amount, msg);
       results.push(result);
     }
 
@@ -308,16 +255,15 @@ impl From<BlsctObj<RangeProof, BlsctRangeProof>> for RangeProof {
 
 impl PartialEq for RangeProof {
   fn eq(&self, other: &Self) -> bool {
-    self.get_A() == other.get_A() &&
-    self.get_B() == other.get_B() &&
-    self.get_r_prime() == other.get_r_prime() &&
-    self.get_s_prime() == other.get_s_prime() &&
-    self.get_delta_prime() == other.get_delta_prime() &&
-    self.get_alpha_hat() == other.get_alpha_hat() &&
-    self.get_tau_x() == other.get_tau_x()
+    self.get_A() == other.get_A()
+      && self.get_B() == other.get_B()
+      && self.get_r_prime() == other.get_r_prime()
+      && self.get_s_prime() == other.get_s_prime()
+      && self.get_delta_prime() == other.get_delta_prime()
+      && self.get_alpha_hat() == other.get_alpha_hat()
+      && self.get_tau_x() == other.get_tau_x()
   }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/ffi/rust/src/scalar.rs
+++ b/ffi/rust/src/scalar.rs
@@ -1,22 +1,12 @@
+use crate::macros::{impl_display, impl_from_retval, impl_value};
 use crate::{
-  blsct_obj::{BlsctObj, self},
+  blsct_obj::{self, BlsctObj},
   blsct_serde::BlsctSerde,
   ffi::{
-    BlsctRetVal,
-    BlsctScalar,
-    deserialize_scalar,
-    gen_scalar,
-    gen_random_scalar,
-    are_scalar_equal,
-    scalar_to_uint64,
-    serialize_scalar,
+    are_scalar_equal, deserialize_scalar, gen_random_scalar, gen_scalar, scalar_to_uint64,
+    serialize_scalar, BlsctRetVal, BlsctScalar,
   },
   util::pad_hex_left,
-};
-use crate::macros::{
-  impl_display,
-  impl_from_retval,
-  impl_value,
 };
 use serde::{Deserialize, Serialize};
 use std::ffi::c_char;
@@ -67,10 +57,12 @@ impl From<BlsctObj<Scalar, BlsctScalar>> for Scalar {
 
 impl PartialEq for Scalar {
   fn eq(&self, other: &Self) -> bool {
-    unsafe { are_scalar_equal(
-      self.obj.as_ptr() as *const BlsctScalar,
-      other.obj.as_ptr() as *const BlsctScalar
-    ) != 0 }
+    unsafe {
+      are_scalar_equal(
+        self.obj.as_ptr() as *const BlsctScalar,
+        other.obj.as_ptr() as *const BlsctScalar,
+      ) != 0
+    }
   }
 }
 
@@ -100,7 +92,7 @@ mod tests {
     for _ in 0..1000 {
       let x = Scalar::random().unwrap();
       let x_u64: u64 = x.into();
-      
+
       if prev == x_u64 {
         dup_tolerance -= 1;
         if dup_tolerance == 0 {
@@ -153,4 +145,3 @@ mod tests {
     assert!(re.is_match(&s));
   }
 }
-

--- a/ffi/rust/src/script.rs
+++ b/ffi/rust/src/script.rs
@@ -1,19 +1,8 @@
 use crate::{
   blsct_obj::BlsctObj,
-  blsct_serde::BlsctSerde, 
-  ffi::{
-    BlsctScript,
-    BlsctRetVal,
-    deserialize_script,
-    SCRIPT_SIZE,
-    serialize_script,
-  },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  blsct_serde::BlsctSerde,
+  ffi::{deserialize_script, serialize_script, BlsctRetVal, BlsctScript, SCRIPT_SIZE},
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   util::gen_random_malloced_buf,
 };
 use serde::{Deserialize, Serialize};
@@ -54,7 +43,7 @@ impl BlsctSerde for Script {
 
 impl PartialEq for Script {
   fn eq(&self, other: &Self) -> bool {
-    self.obj == other.obj 
+    self.obj == other.obj
   }
 }
 
@@ -109,4 +98,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/signature.rs
+++ b/ffi/rust/src/signature.rs
@@ -1,19 +1,8 @@
 use crate::{
   blsct_obj::BlsctObj,
-  blsct_serde::BlsctSerde, 
-  ffi::{
-    BlsctSignature,
-    BlsctRetVal,
-    deserialize_signature,
-    serialize_signature,
-    SIGNATURE_SIZE,
-  },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  blsct_serde::BlsctSerde,
+  ffi::{deserialize_signature, serialize_signature, BlsctRetVal, BlsctSignature, SIGNATURE_SIZE},
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   util::gen_random_malloced_buf,
 };
 use serde::{Deserialize, Serialize};
@@ -54,7 +43,7 @@ impl BlsctSerde for Signature {
 
 impl PartialEq for Signature {
   fn eq(&self, other: &Self) -> bool {
-    self.obj == other.obj 
+    self.obj == other.obj
   }
 }
 
@@ -109,5 +98,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-
-

--- a/ffi/rust/src/sub_addr.rs
+++ b/ffi/rust/src/sub_addr.rs
@@ -1,24 +1,12 @@
 use crate::{
   blsct_obj::BlsctObj,
-  blsct_serde::BlsctSerde, 
+  blsct_serde::BlsctSerde,
   ffi::{
+    derive_sub_address, deserialize_sub_addr, dpk_to_sub_addr, serialize_sub_addr, BlsctRetVal,
     BlsctSubAddr,
-    BlsctRetVal,
-    derive_sub_address,
-    deserialize_sub_addr,
-    dpk_to_sub_addr,
-    serialize_sub_addr,
   },
-  keys::{
-    double_public_key::DoublePublicKey,
-    public_key::PublicKey,
-  },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  keys::{double_public_key::DoublePublicKey, public_key::PublicKey},
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   scalar::Scalar,
   sub_addr_id::SubAddrId,
 };
@@ -35,16 +23,14 @@ impl_display!(SubAddr);
 impl_clone!(SubAddr);
 
 impl SubAddr {
-  pub fn new(
-    view_key: &Scalar,
-    spending_pub_key: &PublicKey,
-    sub_addr_id: &SubAddrId,
-  ) -> Self {
-    let blsct_sub_addr = unsafe { derive_sub_address(
-      view_key.value(),
-      spending_pub_key.value(),
-      sub_addr_id.value(),
-    )};
+  pub fn new(view_key: &Scalar, spending_pub_key: &PublicKey, sub_addr_id: &SubAddrId) -> Self {
+    let blsct_sub_addr = unsafe {
+      derive_sub_address(
+        view_key.value(),
+        spending_pub_key.value(),
+        sub_addr_id.value(),
+      )
+    };
     BlsctObj::from_c_obj(blsct_sub_addr).into()
   }
 
@@ -54,7 +40,9 @@ impl SubAddr {
 impl From<DoublePublicKey> for SubAddr {
   fn from(dpk: DoublePublicKey) -> SubAddr {
     let rv = unsafe { dpk_to_sub_addr(dpk.value()) };
-    BlsctObj::<SubAddr, BlsctSubAddr>::from_retval(rv).unwrap().into()
+    BlsctObj::<SubAddr, BlsctSubAddr>::from_retval(rv)
+      .unwrap()
+      .into()
   }
 }
 
@@ -70,7 +58,7 @@ impl BlsctSerde for SubAddr {
 
 impl PartialEq for SubAddr {
   fn eq(&self, other: &Self) -> bool {
-    self.obj == other.obj 
+    self.obj == other.obj
   }
 }
 
@@ -84,9 +72,7 @@ impl From<BlsctObj<SubAddr, BlsctSubAddr>> for SubAddr {
 mod tests {
   use super::*;
   use crate::{
-    keys::double_public_key::DoublePublicKey,
-    initializer::init,
-    util::gen_random_view_key,
+    initializer::init, keys::double_public_key::DoublePublicKey, util::gen_random_view_key,
   };
 
   #[test]
@@ -119,15 +105,10 @@ mod tests {
     let spending_pub_key = PublicKey::random().unwrap();
     let view_key = gen_random_view_key().unwrap();
     let sub_addr_id = SubAddrId::new(123, 456);
-    
-    let a = SubAddr::new(
-      &view_key,
-      &spending_pub_key,
-      &sub_addr_id,
-    );
+
+    let a = SubAddr::new(&view_key, &spending_pub_key, &sub_addr_id);
     let hex = bincode::serialize(&a).unwrap();
     let b = bincode::deserialize::<SubAddr>(&hex).unwrap();
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/sub_addr_id.rs
+++ b/ffi/rust/src/sub_addr_id.rs
@@ -1,21 +1,11 @@
 use crate::{
   blsct_obj::BlsctObj,
-  blsct_serde::BlsctSerde, 
+  blsct_serde::BlsctSerde,
   ffi::{
-    BlsctSubAddrId,
-    BlsctRetVal,
-    deserialize_sub_addr_id,
-    gen_sub_addr_id,
-    get_sub_addr_id_account,
-    get_sub_addr_id_address,
-    serialize_sub_addr_id,
+    deserialize_sub_addr_id, gen_sub_addr_id, get_sub_addr_id_account, get_sub_addr_id_address,
+    serialize_sub_addr_id, BlsctRetVal, BlsctSubAddrId,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
 };
 use serde::{Deserialize, Serialize};
 use std::ffi::c_char;
@@ -30,10 +20,7 @@ impl_display!(SubAddrId);
 impl_clone!(SubAddrId);
 
 impl SubAddrId {
-  pub fn new(
-    account: i64,
-    address: u64,
-  ) -> Self {
+  pub fn new(account: i64, address: u64) -> Self {
     let blsct_key_id = unsafe { gen_sub_addr_id(account, address) };
     BlsctObj::from_c_obj(blsct_key_id).into()
   }
@@ -61,7 +48,7 @@ impl BlsctSerde for SubAddrId {
 
 impl PartialEq for SubAddrId {
   fn eq(&self, other: &Self) -> bool {
-    self.obj == other.obj 
+    self.obj == other.obj
   }
 }
 
@@ -111,4 +98,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/test_util.rs
+++ b/ffi/rust/src/test_util.rs
@@ -1,17 +1,8 @@
 #[cfg(test)]
 use crate::{
-  ctx::CTx,
-  ctx_id::CTxId,
-  ffi::TxOutputType,
-  keys::child_key::ChildKey,
-  out_point::OutPoint,
-  keys::public_key::PublicKey,
-  scalar::Scalar,
-  sub_addr::SubAddr,
-  sub_addr_id::SubAddrId,
-  token_id::TokenId,
-  tx_in::TxIn,
-  tx_out::TxOut,
+  ctx::CTx, ctx_id::CTxId, ffi::TxOutputType, keys::child_key::ChildKey,
+  keys::public_key::PublicKey, out_point::OutPoint, scalar::Scalar, sub_addr::SubAddr,
+  sub_addr_id::SubAddrId, token_id::TokenId, tx_in::TxIn, tx_out::TxOut,
 };
 
 #[cfg(test)]
@@ -21,11 +12,10 @@ pub fn gen_ctx_actual(
   destination: &SubAddr,
   blinding_key: &Scalar,
 ) -> CTx {
-  let spending_key = ChildKey::random().unwrap()
-    .to_tx_key().to_spending_key();
+  let spending_key = ChildKey::random().unwrap().to_tx_key().to_spending_key();
   let out_point = {
     let ctx_id = CTxId::random();
-    OutPoint::new(&ctx_id, 0).unwrap()
+    OutPoint::new(&ctx_id).unwrap()
   };
   let num_tx_in = 1;
   let num_tx_out = 1;
@@ -33,26 +23,29 @@ pub fn gen_ctx_actual(
   let fee = (num_tx_in + num_tx_out) * default_fee;
   let in_amount = fee + out_amount;
 
+  let gamma = Scalar::new(100).unwrap();
   let tx_in = TxIn::new(
-    in_amount, 
-    100,
+    in_amount,
+    &gamma,
     &spending_key,
-    &TokenId::default().unwrap(), 
+    &TokenId::default().unwrap(),
     &out_point,
-    false, 
-    false
-  ).unwrap();
+    false,
+    false,
+  )
+  .unwrap();
 
   let tx_out = TxOut::new(
-    &destination, 
-    out_amount, 
+    &destination,
+    out_amount,
     msg,
-    &TokenId::default().unwrap(), 
+    &TokenId::default().unwrap(),
     TxOutputType::Normal,
     0,
     false,
     Some(blinding_key),
-  ).unwrap();
+  )
+  .unwrap();
 
   let tx_ins = vec![tx_in];
   let tx_outs = vec![tx_out];
@@ -62,23 +55,12 @@ pub fn gen_ctx_actual(
 #[cfg(test)]
 pub fn gen_ctx() -> CTx {
   let destination = {
-    let view_key = ChildKey::random().unwrap()
-      .to_tx_key().to_view_key();
+    let view_key = ChildKey::random().unwrap().to_tx_key().to_view_key();
     let spending_pub_key = PublicKey::random().unwrap();
     let sub_addr_id = SubAddrId::new(67, 78);
-    SubAddr::new(
-      &view_key,
-      &spending_pub_key, 
-      &sub_addr_id,
-    )
+    SubAddr::new(&view_key, &spending_pub_key, &sub_addr_id)
   };
   let blinding_key = Scalar::random().unwrap();
 
-  gen_ctx_actual(
-    10000,
-    "navio",
-    &destination,
-    &blinding_key,
-  )
+  gen_ctx_actual(10000, "navio", &destination, &blinding_key)
 }
-

--- a/ffi/rust/src/token_id.rs
+++ b/ffi/rust/src/token_id.rs
@@ -1,26 +1,14 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ffi::{
-    BlsctRetVal,
-    BlsctTokenId,
-    deserialize_token_id,
-    gen_default_token_id,
-    gen_token_id,
-    get_token_id_subid,
-    get_token_id_token,
-    gen_token_id_with_token_and_subid,
-    serialize_token_id,
+    deserialize_token_id, gen_default_token_id, gen_token_id, gen_token_id_with_token_and_subid,
+    get_token_id_subid, get_token_id_token, serialize_token_id, BlsctRetVal, BlsctTokenId,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
 };
-use std::ffi::c_char;
 use serde::{Deserialize, Serialize};
+use std::ffi::c_char;
 
 #[derive(Debug, Deserialize, Serialize, Eq)]
 pub struct TokenId {
@@ -44,8 +32,7 @@ impl TokenId {
     Ok(obj.into())
   }
 
-  pub fn from_token_and_subid<'a>(token: u64, subid: u64)
-    -> Result<Self, blsct_obj::Error<'a>> {
+  pub fn from_token_and_subid<'a>(token: u64, subid: u64) -> Result<Self, blsct_obj::Error<'a>> {
     let rv = unsafe { gen_token_id_with_token_and_subid(token, subid) };
     let obj = BlsctObj::from_retval(rv)?;
     Ok(obj.into())
@@ -125,4 +112,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/tx_in.rs
+++ b/ffi/rust/src/tx_in.rs
@@ -1,40 +1,18 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ffi::{
-    BlsctOutPoint,
-    BlsctRetVal,
-    BlsctScalar,
-    BlsctTxIn,
-    BlsctTokenId,
-    buf_to_malloced_hex_c_str,
-    build_tx_in,
-    get_tx_in_amount,
-    get_tx_in_gamma,
-    get_tx_in_spending_key,
-    get_tx_in_token_id,
-    get_tx_in_out_point,
-    get_tx_in_rbf,
-    get_tx_in_staked_commitment,
-    hex_to_malloced_buf,
-    succ,
+    buf_to_malloced_hex_c_str, build_tx_in, get_tx_in_amount, get_tx_in_gamma, get_tx_in_out_point,
+    get_tx_in_rbf, get_tx_in_spending_key, get_tx_in_staked_commitment, get_tx_in_token_id,
+    hex_to_malloced_buf, succ, BlsctOutPoint, BlsctRetVal, BlsctScalar, BlsctTokenId, BlsctTxIn,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   out_point::OutPoint,
   scalar::Scalar,
   token_id::TokenId,
 };
 use serde::{Deserialize, Serialize};
-use std::ffi::{
-  c_char,
-  c_void,
-  CStr,
-};
+use std::ffi::{c_char, c_void, CStr};
 
 #[derive(Debug, Deserialize, Serialize, Eq)]
 pub struct TxIn {
@@ -48,22 +26,24 @@ impl_from_retval!(TxIn);
 impl TxIn {
   pub fn new<'a>(
     amount: u64,
-    gamma: u64,
+    gamma: &Scalar,
     spending_key: &Scalar,
     token_id: &TokenId,
     out_point: &OutPoint,
     is_staked_commitment: bool,
     is_rbf: bool,
   ) -> Result<Self, blsct_obj::Error<'a>> {
-    let rv = unsafe { build_tx_in(
-      amount,
-      gamma,
-      spending_key.value(),
-      token_id.value(),
-      out_point.value(),
-      is_staked_commitment,
-      is_rbf,
-    )};
+    let rv = unsafe {
+      build_tx_in(
+        amount,
+        gamma.value(),
+        spending_key.value(),
+        token_id.value(),
+        out_point.value(),
+        is_staked_commitment,
+        is_rbf,
+      )
+    };
 
     let obj = BlsctObj::from_retval(rv)?;
     Ok(obj.into())
@@ -73,23 +53,24 @@ impl TxIn {
     unsafe { get_tx_in_amount(self.value()) }
   }
 
-  pub fn gamma(&self) -> u64 {
-    unsafe { get_tx_in_gamma(self.value()) }
+  pub fn gamma(&self) -> Scalar {
+    let rv = unsafe { get_tx_in_gamma(self.value()) };
+    BlsctObj::<Scalar, BlsctScalar>::copy_from_c_obj(rv).into()
   }
 
   pub fn spending_key(&self) -> Scalar {
     let rv = unsafe { get_tx_in_spending_key(self.value()) };
-    BlsctObj::<Scalar, BlsctScalar>::from_c_obj(rv).into()
+    BlsctObj::<Scalar, BlsctScalar>::copy_from_c_obj(rv).into()
   }
 
   pub fn token_id(&self) -> TokenId {
     let rv = unsafe { get_tx_in_token_id(self.value()) };
-    BlsctObj::<TokenId, BlsctTokenId>::from_c_obj(rv).into()
+    BlsctObj::<TokenId, BlsctTokenId>::copy_from_c_obj(rv).into()
   }
 
   pub fn out_point(&self) -> OutPoint {
     let rv = unsafe { get_tx_in_out_point(self.value()) };
-    BlsctObj::<OutPoint, BlsctOutPoint>::from_c_obj(rv).into()
+    BlsctObj::<OutPoint, BlsctOutPoint>::copy_from_c_obj(rv).into()
   }
 
   pub fn is_staked_commitment(&self) -> bool {
@@ -105,14 +86,17 @@ impl TxIn {
 
 impl BlsctSerde for TxIn {
   unsafe fn serialize(ptr: *const u8, size: usize) -> *const i8 {
-    buf_to_malloced_hex_c_str(ptr, size) as *const i8
+    buf_to_malloced_hex_c_str(ptr, size)
   }
 
   unsafe fn deserialize(hex: *const c_char) -> *mut BlsctRetVal {
     let buf = hex_to_malloced_buf(hex);
-    let len = CStr::from_ptr(hex).to_str()
-      .expect("Malformed c-string found").len() / 2;
-    succ(buf as *mut c_void, len) 
+    let len = CStr::from_ptr(hex)
+      .to_str()
+      .expect("Malformed c-string found")
+      .len()
+      / 2;
+    succ(buf as *mut c_void, len)
   }
 }
 
@@ -138,11 +122,8 @@ impl PartialEq for TxIn {
 mod tests {
   use super::*;
   use crate::{
-    ctx_id::CTxId,
-    initializer::init,
-    keys::child_key::ChildKey,
-    out_point::OutPoint,
-    token_id::TokenId,
+    ctx_id::CTxId, initializer::init, keys::child_key::ChildKey, out_point::OutPoint,
+    scalar::Scalar, token_id::TokenId,
   };
 
   fn gen_tx_in(amount: u64) -> TxIn {
@@ -150,20 +131,22 @@ mod tests {
       let child_key = ChildKey::random().unwrap();
       child_key.to_tx_key().to_spending_key()
     };
+    let gamma = Scalar::new(42).unwrap();
     let out_point = {
       let ctx_id = CTxId::random();
-      OutPoint::new(&ctx_id, 56).unwrap()
+      OutPoint::new(&ctx_id).unwrap()
     };
     let token_id = TokenId::default().unwrap();
     TxIn::new(
       amount,
-      42,
+      &gamma,
       &spending_key,
       &token_id,
       &out_point,
       false,
       false,
-    ).unwrap()
+    )
+    .unwrap()
   }
 
   #[test]
@@ -179,7 +162,7 @@ mod tests {
     init();
     let tx_in = gen_tx_in(123);
     let gamma = tx_in.gamma();
-    assert_eq!(gamma, 42);
+    assert_eq!(gamma, Scalar::new(42).unwrap());
   }
 
   #[test]
@@ -209,7 +192,7 @@ mod tests {
     init();
     let tx_in = gen_tx_in(123);
     let is_staked_commitment = tx_in.is_staked_commitment();
-    assert_eq!(is_staked_commitment, false); 
+    assert_eq!(is_staked_commitment, false);
   }
 
   #[test]
@@ -217,7 +200,7 @@ mod tests {
     init();
     let tx_in = gen_tx_in(123);
     let is_rbf = tx_in.is_rbf();
-    assert_eq!(is_rbf, false); 
+    assert_eq!(is_rbf, false);
   }
 
   #[test]
@@ -241,4 +224,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/tx_out.rs
+++ b/ffi/rust/src/tx_out.rs
@@ -1,47 +1,20 @@
 use crate::{
-  blsct_obj::{BlsctObj, self},
-  blsct_serde::BlsctSerde, 
+  blsct_obj::{self, BlsctObj},
+  blsct_serde::BlsctSerde,
   ffi::{
-    BLSCT_FAILURE,
-    BlsctRetVal,
-    BlsctScalar,
-    BlsctSubAddr,
-    BlsctTxOut,
-    BlsctTokenId,
-    buf_to_malloced_hex_c_str,
-    build_tx_out,
-    err_bool,
-    get_tx_out_destination,
-    get_tx_out_amount,
-    get_tx_out_memo,
-    get_tx_out_token_id,
-    get_tx_out_output_type,
-    get_tx_out_min_stake,
-    get_tx_out_subtract_fee_from_amount,
-    get_tx_out_blinding_key,
-    hex_to_malloced_buf,
-    succ,
-    TxOutputType,
+    buf_to_malloced_hex_c_str, build_tx_out, err_bool, get_tx_out_amount, get_tx_out_blinding_key,
+    get_tx_out_destination, get_tx_out_memo, get_tx_out_min_stake, get_tx_out_output_type,
+    get_tx_out_subtract_fee_from_amount, get_tx_out_token_id, hex_to_malloced_buf, succ,
+    BlsctRetVal, BlsctScalar, BlsctSubAddr, BlsctTokenId, BlsctTxOut, TxOutputType, BLSCT_FAILURE,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_value},
   scalar::Scalar,
   sub_addr::SubAddr,
   token_id::TokenId,
 };
 use serde::{Deserialize, Serialize};
 use std::{
-  ffi::{
-    c_char,
-    c_void,
-    CStr,
-    CString,
-    NulError,
-  },
+  ffi::{c_char, c_void, CStr, CString, NulError},
   fmt,
   str::Utf8Error,
 };
@@ -58,12 +31,11 @@ impl<'a> std::error::Error for Error<'a> {}
 impl<'a> fmt::Display for Error<'a> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::BlsctObjError(e) =>
-        write!(f, "BlsctObjError: {e:?}"),
-      Error::FailedToCreateCString(e) =>
-        write!(f, "Failed to create CString: {e:?}"),
-      Error::FailedToConvertCStrToStr(e) =>
-        write!(f, "Failed to convert CStr to &str: {e:?}"),
+      Error::BlsctObjError(e) => write!(f, "BlsctObjError: {e:?}"),
+      Error::FailedToCreateCString(e) => write!(f, "Failed to create CString: {e:?}"),
+      Error::FailedToConvertCStrToStr(e) => {
+        write!(f, "Failed to convert CStr to &str: {e:?}")
+      }
     }
   }
 }
@@ -81,39 +53,36 @@ impl TxOut {
     destination: &SubAddr,
     amount: u64,
     memo: &str,
-    token_id: &TokenId,  
+    token_id: &TokenId,
     output_type: TxOutputType,
     min_stake: u64,
     subtract_fee_from_amount: bool,
     opt_blinding_key: Option<&Scalar>,
   ) -> Result<Self, Error<'a>> {
-    let memo_c_str = CString::new(memo)
-      .map_err(|e| Error::FailedToCreateCString(e))?;
-  
-    let zero = Scalar::new(0).unwrap();
-    let blinding_key = opt_blinding_key
-      .unwrap_or_else(|| &zero);
+    let memo_c_str = CString::new(memo).map_err(Error::FailedToCreateCString)?;
 
-    let rv = unsafe { build_tx_out(
-      destination.value(),
-      amount,
-      memo_c_str.as_ptr(),
-      token_id.value(),
-      output_type,
-      min_stake,
-      subtract_fee_from_amount,
-      blinding_key.value(),
-    )};
-    let obj = BlsctObj::from_retval(rv)
-      .map_err(|e| Error::BlsctObjError(e))?;
+    let zero = Scalar::new(0).unwrap();
+    let blinding_key = opt_blinding_key.unwrap_or(&zero);
+
+    let rv = unsafe {
+      build_tx_out(
+        destination.value(),
+        amount,
+        memo_c_str.as_ptr(),
+        token_id.value(),
+        output_type,
+        min_stake,
+        subtract_fee_from_amount,
+        blinding_key.value(),
+      )
+    };
+    let obj = BlsctObj::from_retval(rv).map_err(Error::BlsctObjError)?;
 
     Ok(obj.into())
   }
 
   pub fn destination(&self) -> SubAddr {
-    let obj = unsafe {
-      get_tx_out_destination(self.value())
-    } as *mut BlsctSubAddr;
+    let obj = unsafe { get_tx_out_destination(self.value()) } as *mut BlsctSubAddr;
     BlsctObj::<SubAddr, BlsctSubAddr>::from_c_obj(obj).into()
   }
 
@@ -121,20 +90,17 @@ impl TxOut {
     unsafe { get_tx_out_amount(self.value()) }
   }
 
-  pub fn memo(&self) -> Result<String, Error> {
+  pub fn memo(&self) -> Result<String, Error<'_>> {
     let c_str = unsafe {
       let ptr = get_tx_out_memo(self.value());
       CStr::from_ptr(ptr)
     };
-    let str = c_str.to_str()
-      .map_err(|e| Error::FailedToConvertCStrToStr(e))?;
+    let str = c_str.to_str().map_err(Error::FailedToConvertCStrToStr)?;
     Ok(str.to_owned())
   }
 
   pub fn token_id(&self) -> TokenId {
-    let obj = unsafe {
-      get_tx_out_token_id(self.value())
-    } as *mut BlsctTokenId;
+    let obj = unsafe { get_tx_out_token_id(self.value()) } as *mut BlsctTokenId;
     BlsctObj::<TokenId, BlsctTokenId>::from_c_obj(obj).into()
   }
 
@@ -151,9 +117,7 @@ impl TxOut {
   }
 
   pub fn blinding_key(&self) -> Scalar {
-    let obj = unsafe {
-      get_tx_out_blinding_key(self.value())
-    } as *mut BlsctScalar;
+    let obj = unsafe { get_tx_out_blinding_key(self.value()) } as *mut BlsctScalar;
     BlsctObj::<Scalar, BlsctScalar>::from_c_obj(obj).into()
   }
 
@@ -162,7 +126,7 @@ impl TxOut {
 
 impl BlsctSerde for TxOut {
   unsafe fn serialize(ptr: *const u8, size: usize) -> *const i8 {
-    buf_to_malloced_hex_c_str(ptr, size) as *const i8
+    buf_to_malloced_hex_c_str(ptr, size)
   }
 
   unsafe fn deserialize(hex: *const c_char) -> *mut BlsctRetVal {
@@ -172,8 +136,8 @@ impl BlsctSerde for TxOut {
       Err(_) => err_bool(BLSCT_FAILURE),
       Ok(str) => {
         let len = str.len() / 2;
-        succ(buf as *mut c_void, len) 
-      },
+        succ(buf as *mut c_void, len)
+      }
     }
   }
 }
@@ -200,24 +164,16 @@ mod tests {
   use super::*;
   use crate::{
     initializer::init,
-    keys::{
-      child_key::ChildKey,
-      public_key::PublicKey,
-    },
+    keys::{child_key::ChildKey, public_key::PublicKey},
     sub_addr_id::SubAddrId,
     token_id::TokenId,
   };
 
   fn gen_tx_out(sub_addr_id: &SubAddrId) -> TxOut {
     let destination = {
-      let view_key = ChildKey::random()
-        .unwrap().to_tx_key().to_view_key();
+      let view_key = ChildKey::random().unwrap().to_tx_key().to_view_key();
       let spending_pub_key = PublicKey::random().unwrap();
-      SubAddr::new(
-        &view_key,
-        &spending_pub_key, 
-        &sub_addr_id
-      )
+      SubAddr::new(&view_key, &spending_pub_key, &sub_addr_id)
     };
     let token_id = TokenId::default().unwrap();
 
@@ -226,12 +182,13 @@ mod tests {
       &destination,
       123,
       "navio",
-      &token_id,  
+      &token_id,
       TxOutputType::Normal,
       5,
       false,
       Some(&blinding_key),
-    ).unwrap()
+    )
+    .unwrap()
   }
 
   #[test]
@@ -336,4 +293,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-

--- a/ffi/rust/src/util.rs
+++ b/ffi/rust/src/util.rs
@@ -1,19 +1,12 @@
 use crate::{
   blsct_obj,
-  ffi::{
-    BlsctRetVal,
-    malloc,
-  },
+  ffi::{malloc, BlsctRetVal},
   keys::child_key::ChildKey,
   scalar::Scalar,
 };
 use rand::Rng;
 use std::{
-  ffi::{
-    c_char,
-    CStr,
-    CString,
-  },
+  ffi::{c_char, CStr, CString},
   fmt,
 };
 
@@ -22,23 +15,17 @@ pub enum Error {
   InvalidHexSize(String),
 }
 
-impl<'a> std::error::Error for Error {}
+impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Error::InvalidHexSize(msg) =>
-        write!(f, "Invalid hex size: {msg:?}"),
+      Error::InvalidHexSize(msg) => write!(f, "Invalid hex size: {msg:?}"),
     }
   }
 }
-pub fn c_hex_str_to_array<const N: usize>(
-  raw_hex_c_str: *const c_char
-) -> Result<[u8; N], Error> {
-
-  let hex_c_str = unsafe {
-    std::ffi::CStr::from_ptr(raw_hex_c_str)
-  };
+pub fn c_hex_str_to_array<const N: usize>(raw_hex_c_str: *const c_char) -> Result<[u8; N], Error> {
+  let hex_c_str = unsafe { std::ffi::CStr::from_ptr(raw_hex_c_str) };
   let hex_str = hex_c_str.to_str().unwrap();
 
   let bytes = hex::decode(hex_str).unwrap();
@@ -49,13 +36,10 @@ pub fn c_hex_str_to_array<const N: usize>(
 }
 
 pub fn build_succ_blsct_ret_val<'a, const N: usize>(
-  value: *const u8
+  value: *const u8,
 ) -> Result<*mut BlsctRetVal, blsct_obj::Error<'a>> {
-
   // allocate memory for BlsctRetVal
-  let rv_ptr = unsafe {
-    malloc(std::mem::size_of::<BlsctRetVal>()) as *mut BlsctRetVal
-  };
+  let rv_ptr = unsafe { malloc(std::mem::size_of::<BlsctRetVal>()) as *mut BlsctRetVal };
   if rv_ptr.is_null() {
     return Err(blsct_obj::Error::FailedToAllocateMemory("BlsctRetVal"));
   }
@@ -72,9 +56,7 @@ pub fn build_succ_blsct_ret_val<'a, const N: usize>(
 }
 
 pub fn pad_hex_left<T>(hex: *const c_char) -> CString {
-  let mut h = unsafe {
-    CStr::from_ptr(hex).to_bytes().to_vec()
-  };
+  let mut h = unsafe { CStr::from_ptr(hex).to_bytes().to_vec() };
   let len = std::mem::size_of::<T>() * 2;
 
   if h.len() < len {
@@ -104,4 +86,3 @@ pub fn gen_random_malloced_buf<const N: usize>() -> *mut [u8; N] {
   }
   c_obj
 }
-

--- a/ffi/rust/src/vector_predicate.rs
+++ b/ffi/rust/src/vector_predicate.rs
@@ -1,20 +1,11 @@
 use crate::{
   blsct_obj::BlsctObj,
-  blsct_serde::BlsctSerde, 
+  blsct_serde::BlsctSerde,
   ffi::{
-    BlsctRetVal,
-    BlsctVectorPredicate,
-    deserialize_vector_predicate,
-    are_vector_predicate_equal,
-    serialize_vector_predicate,
+    are_vector_predicate_equal, deserialize_vector_predicate, serialize_vector_predicate,
+    BlsctRetVal, BlsctVectorPredicate,
   },
-  macros::{
-    impl_clone,
-    impl_display,
-    impl_from_retval,
-    impl_size,
-    impl_value,
-  },
+  macros::{impl_clone, impl_display, impl_from_retval, impl_size, impl_value},
 };
 use serde::{Deserialize, Serialize};
 use std::ffi::c_char;
@@ -34,19 +25,11 @@ impl VectorPredicate {
 }
 
 impl BlsctSerde for VectorPredicate {
-  unsafe fn serialize(
-    ptr: *const u8,
-    obj_size: usize,
-  ) -> *const i8 {
-    serialize_vector_predicate(
-      ptr as *const BlsctVectorPredicate,
-      obj_size,
-    )
+  unsafe fn serialize(ptr: *const u8, obj_size: usize) -> *const i8 {
+    serialize_vector_predicate(ptr as *const BlsctVectorPredicate, obj_size)
   }
 
-  unsafe fn deserialize(
-    hex: *const c_char,
-  ) -> *mut BlsctRetVal {
+  unsafe fn deserialize(hex: *const c_char) -> *mut BlsctRetVal {
     deserialize_vector_predicate(hex)
   }
 }
@@ -54,12 +37,7 @@ impl BlsctSerde for VectorPredicate {
 impl PartialEq for VectorPredicate {
   fn eq(&self, other: &Self) -> bool {
     unsafe {
-      are_vector_predicate_equal(
-        self.value(),
-        self.size(),
-        other.value(),
-        other.size(),
-      ) != 0
+      are_vector_predicate_equal(self.value(), self.size(), other.value(), other.size()) != 0
     }
   }
 }
@@ -73,9 +51,7 @@ impl From<BlsctObj<VectorPredicate, BlsctVectorPredicate>> for VectorPredicate {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-  };
+  use crate::initializer::init;
   use std::ffi::c_void;
 
   fn gen_vector_predicate(n: u8) -> VectorPredicate {
@@ -89,10 +65,7 @@ mod tests {
       c_obj
     };
     let obj: BlsctObj<VectorPredicate, BlsctVectorPredicate> =
-      BlsctObj::from_c_obj_and_size(
-        c_obj as *mut c_void, 
-        OBJ_SIZE,
-      );
+      BlsctObj::from_c_obj_and_size(c_obj as *mut c_void, OBJ_SIZE);
     obj.into()
   }
 
@@ -121,5 +94,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-
-

--- a/ffi/rust/src/view_tag.rs
+++ b/ffi/rust/src/view_tag.rs
@@ -1,26 +1,17 @@
 use crate::{
-  blsct_obj,
-  ffi::calc_view_tag,
-  keys::public_key::PublicKey,
+  blsct_obj, ffi::calc_view_tag, keys::public_key::PublicKey, scalar::Scalar,
   util::gen_random_view_key,
-  scalar::Scalar,
 };
 use serde::{Deserialize, Serialize};
 
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ViewTag {
-  value: u64
+  value: u64,
 }
 
 impl ViewTag {
-  pub fn new(
-    blinding_pub_key: &PublicKey,
-    view_key: &Scalar,
-  ) -> Self {
-    let value = unsafe {
-      calc_view_tag(blinding_pub_key.value(), view_key.value()) 
-    };
+  pub fn new(blinding_pub_key: &PublicKey, view_key: &Scalar) -> Self {
+    let value = unsafe { calc_view_tag(blinding_pub_key.value(), view_key.value()) };
     ViewTag { value }
   }
 
@@ -34,10 +25,7 @@ impl ViewTag {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    initializer::init,
-    util::gen_random_view_key,
-  };
+  use crate::{initializer::init, util::gen_random_view_key};
 
   #[test]
   fn test_new() {
@@ -62,4 +50,3 @@ mod tests {
     assert_eq!(a, b);
   }
 }
-


### PR DESCRIPTION
## Summary

- Update `BlsctAmountRecoveryReq`: `nonce`/`token_id` pointer → value types
- Update `BlsctTxIn`: `gamma` field `u64` → `BlsctScalar`
- Update `BlsctTxOut`: add `subtract_fee_from_amount` and `blinding_key` fields
- Fix `OUT_POINT_SIZE`: 36 → 32
- Remove `OutPoint::index()` and `gen_out_point` `n` param (removed upstream)
- Remove `CTxIn::prev_out_n()` (FFI fn removed upstream)
- Change `TxIn::new` gamma param and `TxIn::gamma()` return from `u64` to `&Scalar`/`Scalar`
- Switch getters to `copy_from_c_obj` for non-owning const pointer returns
- Add `BlsctObj::copy_from_c_obj` for safe copies from non-owning C pointers
- Link `stdc++` on Linux, `c++` on macOS
- Bump navio-core SHA to `623ad2da`
- Fix `get_amount_recovery_result_size` return type `i16` → `usize`
- Apply `cargo fmt` across all Rust source files
- Fix clippy warnings: remove unnecessary `as *const i8` casts in `tx_in`/`tx_out`, remove unused lifetime in `util.rs`

## Test plan

- [x] `cargo build` passes on Linux
- [x] `cargo test` passes (116/116)
- [x] `cargo fmt` applied
- [x] `cargo clippy` — no new warnings introduced
- [ ] `cargo build` passes on macOS