### PR TITLE
Expose unsigned-output gamma getter and DATA predicate setter

### DIFF
--- a/ffi/blsct.i
+++ b/ffi/blsct.i
@@ -640,6 +640,8 @@ export BlsctRetVal* build_unsigned_mint_nft_output(
 export void delete_unsigned_output(void* vp_unsigned_output);
 export const char* serialize_unsigned_output(const void* vp_unsigned_output);
 export BlsctRetVal* deserialize_unsigned_output(const char* hex);
+export const BlsctScalar* get_unsigned_output_gamma(const void* vp_unsigned_output);
+export bool set_unsigned_output_data_predicate(void* vp_unsigned_output, const char* data_hex);
 
 export void* create_unsigned_transaction();
 export void add_unsigned_transaction_input(void* vp_unsigned_transaction, const void* vp_unsigned_input);


### PR DESCRIPTION
## Summary

Adds two functions to the shared SWIG contract (`ffi/blsct.i`):

- `get_unsigned_output_gamma(vp_unsigned_output)` -> serialized scalar
- `set_unsigned_output_data_predicate(vp_unsigned_output, data_hex)` -> bool

They wrap the navio-core external-API additions from nav-io/navio-core#318 and enable **delegated cold staking** from wallets built on these bindings (nav-io/navio-core#304): read the built output's gamma, encrypt the delegation payload `(value, gamma, reward address)` to the operator, and attach it as a DATA predicate *before* signing - the predicate is covered by the output's ownership signature, so it cannot be added afterwards.

## Notes

- Requires a navio-core checkout containing nav-io/navio-core#318; builds against older cores will fail to link these two symbols, so this should merge after the core PR lands and the pinned core SHA moves past it.
- First consumer: navio-electrum's `delegatestake` (nav-io/navio-electrum#1), which feature-detects `set_unsigned_output_data_predicate` and degrades gracefully on older bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)